### PR TITLE
Add the proper hostname for eternum.io

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -8,7 +8,7 @@
 	"https://ipfs.jes.xxx/ipfs/:hash",
 	"https://catalunya.network/ipfs/:hash",
 	"https://siderus.io/ipfs/:hash",
-	"https://eternum.io/ipfs/:hash",
+	"https://www.eternum.io/ipfs/:hash",
 	"https://hardbin.com/ipfs/:hash",
 	"https://ipfs.macholibre.org/ipfs/:hash",
 	"https://ipfs.works/ipfs/:hash",


### PR DESCRIPTION
This commit adds the www prefix to eternum.io, so it doesn't redirect and the correct CORS header gets loaded.