### PR TITLE
Update http to https for rx14.co.uk

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -2,7 +2,7 @@
 	"https://ipfs.io/ipfs/:hash",
 	"https://gateway.ipfs.io/ipfs/:hash",
 	"https://ipfs.infura.io/ipfs/:hash",
-	"http://rx14.co.uk/ipfs/:hash",
+	"https://rx14.co.uk/ipfs/:hash",
 	"https://xmine128.tk/ipfs/:hash",
 	"https://upload.global/ipfs/:hash",
 	"https://ipfs.jes.xxx/ipfs/:hash",


### PR DESCRIPTION
There's already a 301 redirect in place, though the gateway itself is still offline (404):

From the cli:

```
❯ ipfg -M http://rx14.co.uk/ipfs/:hash
Offline	https://rx14.co.uk	[301: http://rx14.co.uk]

❯ ipfg -M https://rx14.co.uk/ipfs/:hash
Offline	https://rx14.co.uk	[404]
```