### PR TITLE
Opt-out from gateway redirects done by IPFS Companion

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,9 @@ function checkGateways (gateways) {
   let checked = 0
   gateways.forEach((gateway) => {
     const gatewayAndHash = gateway.replace(':hash', hashToTest)
-    fetch(gatewayAndHash)
+    // opt-out from gateway redirects done by browser extension
+    const testUrl = gatewayAndHash + '#x-ipfs-no-redirect'
+    fetch(testUrl)
       .then(res => res.text())
       .then((text) => {
         const matched = text.trim() === hashString.trim()

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ function checkGateways (gateways) {
   gateways.forEach((gateway) => {
     const gatewayAndHash = gateway.replace(':hash', hashToTest)
     // opt-out from gateway redirects done by browser extension
-    const testUrl = gatewayAndHash + '#x-ipfs-no-redirect'
+    const testUrl = gatewayAndHash + '#x-ipfs-companion-no-redirect'
     fetch(testUrl)
       .then(res => res.text())
       .then((text) => {


### PR DESCRIPTION
[Our browser extension](https://github.com/ipfs/ipfs-companion) redirects request to gateways, which breaks this status page. Additionally, due to a [workaround](https://github.com/ipfs-shipyard/ipfs-companion/pull/494) for [CORS bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1450965)  it  produces [different results under Chrome and Firefox](https://user-images.githubusercontent.com/157609/41968786-afd51498-7a05-11e8-9941-130034ceb29f.png).

**TL;DR** we don't want browser extension to touch requests made by public-gateway-checker
This PR  adds an explicit opt-out hint that ensures test requests reach the right gateway.

More info about opt-out URL hint: https://github.com/ipfs-shipyard/ipfs-companion/pull/505 
(to be released with next version of browser extension)

cc @VictorBjelkholm 
