### PR TITLE
Add gateway at ipfs.dapps.earth

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -22,5 +22,5 @@
 	"https://ipfs.netw0rk.io/ipfs/:hash",
 	"https://gateway.swedneck.xyz/ipfs/:hash",
 	"http://10.139.105.114:8080/ipfs/:hash",
-	"http://ipfs.dapps.earth/ipfs/:hash"
+	"https://ipfs.dapps.earth/ipfs/:hash"
 ]

--- a/gateways.json
+++ b/gateways.json
@@ -22,5 +22,5 @@
 	"https://ipfs.netw0rk.io/ipfs/:hash",
 	"https://gateway.swedneck.xyz/ipfs/:hash",
 	"http://10.139.105.114:8080/ipfs/:hash",
-	"https://ipfs.dapps.earth/ipfs/:hash"
+	"https://ipfs.staging.dapps.earth/ipfs/:hash"
 ]

--- a/gateways.json
+++ b/gateways.json
@@ -21,5 +21,6 @@
 	"https://ipns.co/:hash",
 	"https://ipfs.netw0rk.io/ipfs/:hash",
 	"https://gateway.swedneck.xyz/ipfs/:hash",
-	"http://10.139.105.114:8080/ipfs/:hash"
+	"http://10.139.105.114:8080/ipfs/:hash",
+	"http://ipfs.dapps.earth/ipfs/:hash"
 ]

--- a/gateways.json
+++ b/gateways.json
@@ -22,5 +22,5 @@
 	"https://ipfs.netw0rk.io/ipfs/:hash",
 	"https://gateway.swedneck.xyz/ipfs/:hash",
 	"http://10.139.105.114:8080/ipfs/:hash",
-	"https://ipfs.staging.dapps.earth/ipfs/:hash"
+	"https://ipfs.dapps.earth/ipfs/:hash"
 ]


### PR DESCRIPTION
Test plan: https://rawgit.com/burdakovd/public-gateway-checker/c27602cbfc6b99deda97f323789b1cb708001392/

More info about the gateway at dapps.earth
Key feature: content is served from subdomains for better origin-based isolation, e.g. https://ipfs.dapps.earth/ipfs/Qmaisz6NMhDB51cCvNWa1GMS7LU1pAxdF4Ld6Ft9kZEP2a is redirected to https://bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m.ipfs.dapps.earth/