### PR TITLE
Add ipfs.greyh.at to gateways.json

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -21,5 +21,6 @@
 	"https://ipns.co/:hash",
 	"https://ipfs.netw0rk.io/ipfs/:hash",
 	"https://gateway.swedneck.xyz/ipfs/:hash",
+	"https://ipfs.greyh.at/ipfs/:hash",
 	"http://10.139.105.114:8080/ipfs/:hash"
 ]


### PR DESCRIPTION
Just adds another public IPFS gateway to the list. This gateway is hosted on a good connection, and should be useful to the community. =)