### PR TITLE
Add IPFS-Browser-Gateway

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -38,5 +38,6 @@
 	"https://ipfs.fooock.com/ipfs/:hash",
 	"https://ipfstube.erindachtler.me/ipfs/:hash",
 	"https://cdn.cwinfo.net/ipfs/:hash",
-	"https://ipfs.privacytools.io/ipfs/:hash"
+	"https://ipfs.privacytools.io/ipfs/:hash",
+	"https://onetwo.ren/ipfs-browser-gateway/ipfs/:hash"
 ]


### PR DESCRIPTION
Repo: https://github.com/linonetwo/ipfs-browser-gateway

Example: https://onetwo.ren/ipfs-browser-gateway/ipfs/QmXD8TDFDn7kfsmCD2eQ3QWuhLpvj7LB5tbzU44iypdmQ9

I'm not sure whether this will work in this gateway checker, since it relies on service-worker to work, and only work in client-side which supports sw.