### PR TITLE
feat: add public subdomain gateways and Origin check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # ipfs/public-gateway-checker
 
-Checks which public IPFS gateways are online or not.
-
-NOTE: All of these (except gateway.ipfs.io and ipfs.io) are hosted by third-parties and should be treated as such.
+> Checks which public IPFS gateways are online or not.
 
 You can view this website on GitHub Pages: https://ipfs.github.io/public-gateway-checker/
 
-Here's a screenshot:
+[![screenshot_2019-12-14.png](https://ipfs.io/ipfs/QmX53EdPJxH377WHfwH8wV3tu8Zzjq9ojgQS6U82JRM6bd?filename=screenshot_2019-12-14.png)](https://ipfs.github.io/public-gateway-checker/)
 
-[![screenshot](https://ipfs.io/ipfs/QmUeCSd4gHio7MxZuRXCcLFXED9GpfntKcL87gmXvZV3ed)](https://ipfs.github.io/public-gateway-checker/)
 
-A CLI version `ipfg` is available here: https://github.com/JayBrown/Tools/tree/master/ipfg
+
+**NOTE:** All of these (except `ipfs.io` and `dweb.link`) are hosted by third-parties and should be treated as such.
+
+
+## Adding a new public gateway
 
 If you'd like to add a new public gateway, please edit `gateways.json` and submit a pull request.
+
+
+## Command line
+
+A CLI version `ipfg` is available here: https://github.com/JayBrown/Tools/tree/master/ipfg

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
-const HASH_TO_TEST = 'Qmaisz6NMhDB51cCvNWa1GMS7LU1pAxdF4Ld6Ft9kZEP2a';
-const SCRIPT_HASH = 'QmYHbXzTCbjavphzqrTe7zYYMW8HyeuMLNcLbqiUkj9TAH';
+const HASH_TO_TEST = 'bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m';
+const SCRIPT_HASH = 'bafybeietzsezxbgeeyrmwicylb5tpvf7yutrm3bxrfaoulaituhbi7q6yi';
 const HASH_STRING = 'Hello from IPFS Gateway Checker';
 
 // checker is the program root, it contains all involved objects
@@ -113,6 +113,29 @@ Cors.prototype.onerror = function() {
 // ////////////////////////////////////////////////////////////////////////////////////
 
 // ////////////////////////////////////////////////////////////////////////////////////
+// ORIGIN
+let Origin = function(parent) {
+	this.parent = parent;
+
+	this.tag = document.createElement("span");
+	this.tag.textContent = ' ORIGIN: 🕑 - ';
+};
+
+Origin.prototype.check = function() {
+	const cidInSubdomain = this.parent.gateway.startsWith('https://:hash.ipfs.');
+	if (cidInSubdomain) {
+		this.tag.textContent = ' ORIGIN: ✅ - ';
+	} else {
+		this.onerror();
+	}
+};
+
+Origin.prototype.onerror = function() {
+	this.tag.textContent = ' ORIGIN: ❌ - ';
+};
+// ////////////////////////////////////////////////////////////////////////////////////
+
+// ////////////////////////////////////////////////////////////////////////////////////
 // NODE
 let Node = function(parent, gateway, index) {
 	this.parent = parent;
@@ -124,6 +147,9 @@ let Node = function(parent, gateway, index) {
 
 	this.cors = new Cors(this);
 	this.tag.append(this.cors.tag);
+
+	this.origin = new Origin(this);
+	this.tag.append(this.origin.tag);
 
 	this.link = document.createElement("span");
 	this.link.textContent = gateway.replace(':hash', HASH_TO_TEST);
@@ -141,6 +167,7 @@ Node.prototype.check = function() {
 	this.checkingTime = performance.now();
 	this.status.check();
 	this.cors.check();
+	this.origin.check();
 };
 
 Node.prototype.checked = function() {
@@ -149,7 +176,7 @@ Node.prototype.checked = function() {
 
 	let gatewayTitle = this.gateway.split(":hash")[0];
 	let gatewayAndHash = this.gateway.replace(':hash', HASH_TO_TEST);
-	this.link.innerHTML = `<a title="${gatewayTitle}"href="${gatewayAndHash}"target="_blank">${gatewayAndHash}</a>`;
+	this.link.innerHTML = `<a title="${gatewayTitle}" href="${gatewayAndHash}#x-ipfs-companion-no-redirect" target="_blank">${gatewayAndHash}</a>`;
 
 	if (!this.tested) {
 		let ms = (performance.now() - this.checkingTime).toFixed(2);
@@ -178,4 +205,3 @@ function checkGateways (gateways) {
 fetch('./gateways.json')
 	.then(res => res.json())
 	.then(gateways => checkGateways(gateways));
-

--- a/gateways.json
+++ b/gateways.json
@@ -1,5 +1,6 @@
 [
 	"https://ipfs.io/ipfs/:hash",
+	"https://:hash.ipfs.dweb.link",
 	"https://gateway.ipfs.io/ipfs/:hash",
 	"https://ipfs.infura.io/ipfs/:hash",
 	"https://rx14.co.uk/ipfs/:hash",
@@ -17,6 +18,7 @@
 	"https://gateway.blocksec.com/ipfs/:hash",
 	"https://ipfs.renehsz.com/ipfs/:hash",
 	"https://cloudflare-ipfs.com/ipfs/:hash",
+	"https://:hash.ipfs.cf-ipfs.com",
 	"https://ipns.co/:hash",
 	"https://ipfs.mrh.io/ipfs/:hash",
 	"https://gateway.originprotocol.com/ipfs/:hash",


### PR DESCRIPTION
This PR adds:
- status next to each gateway to highlight which gateways provide Origin isolation 
- two known public gateways that support [CID in Subdomain](https://docs.ipfs.io/guides/guides/addressing/#subdomain-gateway)

Preview:
[![screenshot_2019-12-14.png](https://ipfs.io/ipfs/QmX53EdPJxH377WHfwH8wV3tu8Zzjq9ojgQS6U82JRM6bd?filename=screenshot_2019-12-14.png)](https://ipfs.github.io/public-gateway-checker/)

cc @autonome, https://github.com/ipfs/ipfs/issues/337, https://github.com/ipfs/in-web-browsers/issues/89, https://github.com/ipfs/go-ipfs/issues/6498