### PR TITLE
UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ You can view this website on GitHub Pages: https://ipfs.github.io/public-gateway
 
 **NOTE:** All of these (except `ipfs.io` and `dweb.link`) are hosted by third-parties and should be treated as such.
 
-
 ## Adding a new public gateway
 
 If you'd like to add a new public gateway, please edit `gateways.json` and submit a pull request.
 
+## Testing locally
+
+```console
+$ npx http-server . -a 127.0.0.1 -p 3000 -c-1
+```
 
 ## Command line
 

--- a/index.html
+++ b/index.html
@@ -6,15 +6,26 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<meta name="mobile-web-app-capable" content="yes">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tachyons@4.11.1/css/tachyons.min.css" integrity="sha256-XiJ+PedljEmPP2VaQzSzekfCZdPr0fpqmh9dY6kpsuQ=" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ipfs-css@0.13.1/ipfs.css" integrity="sha256-crEOQ/1aKoWgku50e0aqNzt0Tt/ev2C97PVr5hGpeEY=" crossorigin="anonymous">
 	<link href="styles.css" type="text/css" rel="stylesheet"/>
 </head>
-<body id="checker">
-	<div class="Header"><a href="https://ipfs.io" target="_blank" title="ipfs.io"><img src="https://ipfs.io/ipfs/QmTqZhR6f7jzdhLgPArDPnsbZpvvgxzCZycXK7ywkLxSyU?filename=ipfs-logo.3ea91a2f.svg" height="50"></a><div class="Title">Public Gateways</div></div>
-	<div id="checker.stats" class="Stats"></div>
-	<div id="checker.results" class="Results">
-		<div class="Node"><div class="Status">UP</div><div class="Cors">cors</div><div class="Origin" title="Orign Isolation">
-		<a href="https://docs.ipfs.io/guides/guides/addressing/#subdomain-gateway" target="_blank">OI</a></div><div class="Link"></div><div class="Took">resp</div></div>
+<body id="checker" class="sans-serif charcoal bg-snow-muted">
+	<div class="Header">
+		<a href="https://ipfs.io" target="_blank" title="ipfs.io" class="pa2"><img src="https://ipfs.io/ipfs/QmTqZhR6f7jzdhLgPArDPnsbZpvvgxzCZycXK7ywkLxSyU?filename=ipfs-logo.3ea91a2f.svg" height="50px"></a>
+		<div class="Title montserrat">Public Gateways</div>
+		<!-- GitHub Corner from https://github.com/tholman/github-corners --><a href="https://github.com/ipfs/public-gateway-checker" target="_blank" class="github-corner db" aria-label="View source on GitHub"  title="View source on GitHub"><svg height="80px" viewBox="0 0 250 250" style="fill:#64C2CA; color:#0B3A53;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+	</div>
+	<div id="checker.stats" class="Stats monospace f6"></div>
+	<div id="checker.results" class="Results monospace f6">
+		<div class="Node">
+			<div class="Status truncate" title="Online status" style="cursor: help">Online</div>
+			<div class="Cors truncate" title="Allows Cross-Origin Resource Sharing"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers" target="_blank" style="cursor: help">CORS</a></div>
+			<div class="Origin truncate" title="Provides Orign Isolation"><a href="https://docs.ipfs.io/guides/guides/addressing/#subdomain-gateway" target="_blank" style="cursor: help">Origin</a></div>
+			<div class="Link truncate">Hostname</div>
+			<div class="Took">ΔT</div>
+		</div>
 	</div>
 </body>
-<script src="./app.js?v=0.1"></script>
+<script src="./app.js?v=0.2"></script>
 </html>

--- a/lastpubver
+++ b/lastpubver
@@ -1,1 +1,1 @@
-QmXrBoBPBMRhcmKWNKcXoNgXBA1Gfoe5gqkPPNB7RChwJr
+bafybeih5ijnzskerps5zc6uhvmtsl7hf2bkjcfh3t26cpm7cj7u2j3pkq4

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,4 @@
 body, html {
-	font-family: monospace;
-	color: #222;
-	background-color: #FAFAFA;
-	margin: 0;
-	padding: 0;
 	box-sizing: border-box;
 	text-align: center;
 }
@@ -12,24 +7,21 @@ div.Header {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	width: calc(100% - 2rem);
+	width: 100%;
 	background-color: #0b3a53;
 	padding: 1rem;
+	margin: 0;
+	padding: 0;
 }
 
 div.Header a {
 	box-sizing: border-box;
 }
 
-div.Header a img {
-	height: 50px;
-}	
-
 div.Header div.Title {
 	position: relative;
 	display: inline-block;
 	color: #69c4cd;
-	font-family: Montserrat,Verdana,system-ui,sans-serif;
 	font-size: 1.5rem;
 	text-align: right;
 	font-weight: 200;
@@ -51,6 +43,7 @@ div.Stats div.Gateways {
 	font-weight: bold;
 	padding: 0.5em 1em;
 	margin: 0 1em 0 0;
+	font-family: Consolas, monaco, monospace;
 }
 
 div.Stats div.Gateways {
@@ -58,7 +51,7 @@ div.Stats div.Gateways {
 }
 
 div.Stats div.Totals {
-	background-color: rgb(0, 181, 0);
+	background-color: #0cb892;
 }
 
 div.Results {
@@ -74,18 +67,25 @@ div.Node {
 	display: flex;
 	justify-content: space-evenly;
 	align-items: center;
-	width: 95%;
-	padding: 0.5em 0;
-	margin: 0 2.5%;
-	border-bottom: 1px solid #EEE;
+	border-bottom: 1px solid #edf0f4;
+	padding: 0.5em 1em;
 }
+
+div.Node:hover {
+	background-color: #edf0f4;
+}
+
 
 div.Node div.Link {
 	width: 100%;
 	text-align: left;
+	padding-left: 1em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
-div.Node div.Link a {
+div.Node a {
 	text-decoration: none;
 	color: #357edd;
 	white-space: nowrap;
@@ -94,20 +94,15 @@ div.Node div.Link a {
 div.Node div.Status,
 div.Node div.Cors,
 div.Node div.Origin {
-	width: 4em;
+	width: 5em;
 	text-align: center;
-	font-weight: bold;
-}
-
-div.Node div.Cors,
-div.Node div.Origin {
-	font-size: 80%;
+	margin: 0 0.5em;
+	user-select: none;
 }
 
 div.Node div.Took {
-	width: 5em;
+	min-width: 5em;
 	text-align: right;
 	font-size: 80%;
 	font-style: italic;
 }
-


### PR DESCRIPTION
Various UX tweaks on top of #83 by @lazyweirdo: 

- added link to github repo in the right corner (https://github.com/tholman/github-corners)
- switched to colors and fonts from https://github.com/ipfs-shipyard/ipfs-css
  - I did not rewrite entire thing to use tachyons to keep this PR small
- same font size in all columns (fixes [this bug](https://user-images.githubusercontent.com/157609/71595476-2232ad00-2b3c-11ea-8f95-511af4fe28a2.png))
- improved links about CORS and Origin tests
- removed `.ipfs.` from displayed hostnames of subdomain gateways
- long hostnames get truncated on narrow screens without breaking layout ([demo](https://user-images.githubusercontent.com/157609/71595837-7e4a0100-2b3d-11ea-8511-9d69219717cd.png))
- README: added note how to test locally:
  ```
  $ npx http-server . -a 127.0.0.1 -p 3000 -c-1
  ```


## TODO

- [ ] get :+1: from someone with MS Windows and Max OS (@jamiew? @lazyweirdo?)
     - just open [this](http://bafybeih5ijnzskerps5zc6uhvmtsl7hf2bkjcfh3t26cpm7cj7u2j3pkq4.ipfs.dweb.link/) and let me know if anything looks off


## Preview

LIVE: http://bafybeih5ijnzskerps5zc6uhvmtsl7hf2bkjcfh3t26cpm7cj7u2j3pkq4.ipfs.dweb.link/

### Screenshots

> ![Screen Shot 2019-12-30 at 19 48 45](https://user-images.githubusercontent.com/157609/71595820-70947b80-2b3d-11ea-850d-393555affd8e.png)


Narrow screen (like iPhone XS):

> ![Screen Shot 2019-12-30 at 19 49 19](https://user-images.githubusercontent.com/157609/71595837-7e4a0100-2b3d-11ea-8511-9d69219717cd.png)

