### PR TITLE
Add storjipfs-gateway.com

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -34,5 +34,6 @@
 	"https://ipfs.stibarc.gq/ipfs/:hash",
 	"https://ipfs.best-practice.se/ipfs/:hash",
 	"https://:hash.ipfs.2read.net",
-	"https://ipfs.2read.net/ipfs/:hash"
+	"https://ipfs.2read.net/ipfs/:hash",
+	"https://storjipfs-gateway.com/ipfs/:hash"
 ]


### PR DESCRIPTION
So... I don't actually know if https://storjipfs-gateway.com/ is supposed to be a permanent thing.. but it's out there. When you upload something to https://storjipfs.com/ it links to your upload on that gateway.