### PR TITLE
Header from IPLD Explorer; removes css extraneous to tachyons

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,19 +11,35 @@
 	<link href="styles.css" type="text/css" rel="stylesheet"/>
 </head>
 <body id="checker" class="sans-serif charcoal bg-snow-muted">
-	<div class="Header">
-		<a href="https://ipfs.io" target="_blank" title="ipfs.io" class="pa2"><img src="https://ipfs.io/ipfs/QmTqZhR6f7jzdhLgPArDPnsbZpvvgxzCZycXK7ywkLxSyU?filename=ipfs-logo.3ea91a2f.svg" height="50px"></a>
-		<div class="Title montserrat">Public Gateways</div>
-		<!-- GitHub Corner from https://github.com/tholman/github-corners --><a href="https://github.com/ipfs/public-gateway-checker" target="_blank" class="github-corner db" aria-label="View source on GitHub"  title="View source on GitHub"><svg height="80px" viewBox="0 0 250 250" style="fill:#64C2CA; color:#0B3A53;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
-	</div>
-	<div id="checker.stats" class="Stats monospace f6"></div>
-	<div id="checker.results" class="Results monospace f6">
-		<div class="Node">
-			<div class="Status truncate" title="Online status" style="cursor: help">Online</div>
-			<div class="Cors truncate" title="Allows Cross-Origin Resource Sharing"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers" target="_blank" style="cursor: help">CORS</a></div>
-			<div class="Origin truncate" title="Provides Orign Isolation"><a href="https://docs.ipfs.io/guides/guides/addressing/#subdomain-gateway" target="_blank" style="cursor: help">Origin</a></div>
-			<div class="Link truncate">Hostname</div>
-			<div class="Took">ΔT</div>
+
+	<header class='flex-l items-center pa3 bg-navy bb bw3 border-aqua tc tl-l'>
+		<a href="https://ipfs.io" target="_blank" title="ipfs.io" class='flex-none v-mid'>
+			<img src="https://ipfs.io/ipfs/QmTqZhR6f7jzdhLgPArDPnsbZpvvgxzCZycXK7ywkLxSyU?filename=ipfs-logo.3ea91a2f.svg" alt="IPFS" height="50px" width="117.5px" />
+		</a>
+		<div class='flex-auto'>
+		</div>
+		<div class='pt2 pt0-l ma0 inline-flex items-center'>
+			<h1 class='f3 fw2 montserrat aqua ttu ma0'>Public Gateways</h1>
+			<div class='pl3'>
+				<a href='https://github.com/ipfs/public-gateway-checker' target='_blank' rel="noopener noreferrer" aria-label='View source on GitHub'>
+					<svg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 32.58 31.77'>
+						<path fill='#7f8491' d='M16.29 0a16.29 16.29 0 00-5.15 31.75c.82.15 1.11-.36 1.11-.79v-2.77C7.7 29.18 6.74 26 6.74 26a4.36 4.36 0 00-1.81-2.39c-1.47-1 .12-1 .12-1a3.43 3.43 0 012.49 1.68 3.48 3.48 0 004.74 1.36 3.46 3.46 0 011-2.18c-3.62-.41-7.42-1.81-7.42-8a6.3 6.3 0 011.67-4.37 5.94 5.94 0 01.16-4.31s1.37-.44 4.48 1.67a15.41 15.41 0 018.16 0c3.11-2.11 4.47-1.67 4.47-1.67a5.91 5.91 0 01.2 4.28 6.3 6.3 0 011.67 4.37c0 6.26-3.81 7.63-7.44 8a3.85 3.85 0 011.11 3v4.47c0 .53.29.94 1.12.78A16.29 16.29 0 0016.29 0z'/>
+					</svg>
+				</a>
+			</div>
+		</div>
+	</header>
+
+	<div class="ph4-l pt4-l">
+		<div id="checker.stats" class="Stats monospace f6"></div>
+		<div id="checker.results" class="Results monospace f6">
+			<div class="Node">
+				<div class="Status truncate" title="Online status" style="cursor: help">Online</div>
+				<div class="Cors truncate" title="Allows Cross-Origin Resource Sharing"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers" target="_blank" style="cursor: help">CORS</a></div>
+				<div class="Origin truncate" title="Provides Orign Isolation"><a href="https://docs.ipfs.io/guides/guides/addressing/#subdomain-gateway" target="_blank" style="cursor: help">Origin</a></div>
+				<div class="Link truncate">Hostname</div>
+				<div class="Took">ΔT</div>
+			</div>
 		</div>
 	</div>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -3,30 +3,6 @@ body, html {
 	text-align: center;
 }
 
-div.Header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	width: 100%;
-	background-color: #0b3a53;
-	padding: 1rem;
-	margin: 0;
-	padding: 0;
-}
-
-div.Header a {
-	box-sizing: border-box;
-}
-
-div.Header div.Title {
-	position: relative;
-	display: inline-block;
-	color: #69c4cd;
-	font-size: 1.5rem;
-	text-align: right;
-	font-weight: 200;
-}
-
 div.Stats {
 	display: flex;
 	justify-content: flex-start;


### PR DESCRIPTION
Ref https://github.com/ipfs-shipyard/ipld-explorer/pull/57#pullrequestreview-421960888: Clones visual style of GitHub link from IPLD Explorer. Also removes some CSS rendered extraneous by use of tachyons.