### PR TITLE
remove filecoin.io as a gateway

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -39,7 +39,6 @@
 	"https://ipfs.lc/ipfs/:hash",
 	"https://ipfs.leiyun.org/ipfs/:hash",
 	"https://ipfs.ink/ipfs/:hash",
-	"https://filecoin.io/ipfs/:hash",
 	"https://ipfs.jes.xxx/ipfs/:hash",
 	"https://ipfs.oceanprotocol.com/ipfs/:hash",
 	"https://d26g9c7mfuzstv.cloudfront.net/ipfs/:hash",


### PR DESCRIPTION
It is not intended to function as an IPFS gateway.