### PR TITLE
Remove jes.xxx gateway

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -39,7 +39,6 @@
 	"https://ipfs.lc/ipfs/:hash",
 	"https://ipfs.leiyun.org/ipfs/:hash",
 	"https://ipfs.ink/ipfs/:hash",
-	"https://ipfs.jes.xxx/ipfs/:hash",
 	"https://ipfs.oceanprotocol.com/ipfs/:hash",
 	"https://d26g9c7mfuzstv.cloudfront.net/ipfs/:hash",
 	"https://ipfsgateway.makersplace.com/ipfs/:hash",


### PR DESCRIPTION
The jes.xxx domain is too expensive to keep renewing so I'll be getting rid of it in time.

(If anyone wants to buy it please let me know!).