### PR TITLE
feat: add bluelight.link

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -60,5 +60,6 @@
 	"https://gw.ipfspin.com/ipfs/:hash",
 	"https://ipfs.kavin.rocks/ipfs/:hash",
 	"https://ipfs.denarius.io/ipfs/:hash",
-	"https://ipfs.mihir.ch/ipfs/:hash"
+	"https://ipfs.mihir.ch/ipfs/:hash",
+	"https://bluelight.link:hash"
 ]


### PR DESCRIPTION
- VPS hosted on Vultr Singapore
- IPFS server 0.8.0-rc1
- GO 1.15.6
- 15Gb space
- Subdomain gateway support
- CORS free
