### PR TITLE
Update gateway domain

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -37,7 +37,7 @@
 	"https://trusti.id/ipfs/:hash",
 	"https://apac.trusti.id/ipfs/:hash",
 	"https://ipfs.overpi.com/ipfs/:hash",
-	"https://ipfs.lc/ipfs/:hash",
+	"https://gateway.ipfs.lc/ipfs/:hash",
 	"https://ipfs.leiyun.org/ipfs/:hash",
 	"https://ipfs.ink/ipfs/:hash",
 	"https://ipfs.oceanprotocol.com/ipfs/:hash",


### PR DESCRIPTION
I changed the gateway address to a subdomain name some time ago, and it is now online again.

The server is located in France, a gigabit network, and the cache limit is set to 1TB. and use cloudflare gateway to distribute data.

