### PR TITLE
feat: add decoo.io

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -83,5 +83,6 @@
 	"https://ipfs.taxi/ipfs/:hash",
 	"https://ipfs.scalaproject.io/ipfs/:hash", 
 	"https://search.ipfsgate.com/ipfs/:hash",
-	"https://ipfs.itargo.io/ipfs/:hash"
+	"https://ipfs.itargo.io/ipfs/:hash",
+	"https://ipfs.decoo.io/ipfs/:hash"
 ]


### PR DESCRIPTION
This gateway is a ubuntu 18.04 server located in Hongkong, with 400GB SSD disk space.

_https://ipfs.decoo.io_ is proxyed and protected by Cloudflare.
 
The network bandwidth is _Download: 95.17 Mbit/s, Upload: 4.17 Mbit/s_ (tested by speedtest).