### PR TITLE
feat: remove smartsignature.io

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -44,7 +44,6 @@
 	"https://d26g9c7mfuzstv.cloudfront.net/ipfs/:hash",
 	"https://ipfsgateway.makersplace.com/ipfs/:hash",
 	"https://gateway.ravenland.org/ipfs/:hash",
-	"https://ipfs.smartsignature.io/ipfs/:hash",
 	"https://ipfs.funnychain.co/ipfs/:hash",
 	"https://ipfs.telos.miami/ipfs/:hash",
 	"https://robotizing.net/ipfs/:hash",


### PR DESCRIPTION
<!--
Hello! To ensure this PR is correctly addressed as soon as possible by the IPFS team, please be sure of the following:

IF ADDING A NEW PUBLIC GATEWAY:
- Name your PR in the format `feat: add gateway.address.here`
- Make sure there is no trailing comma in the final gateway in the list at `gateways.json`
- Include a brief description of the gateway to be added (e.g. geographic location, connection speed, available space, etc)

ALL OTHER PULL REQUESTS:
- Name your PR in the format `feat: description`, `fix: description`, `docs: description`, `chore: description`, etc
- Be as complete in your description of changes as possible; if there is an impact on the UI, please include screenshots
- Reference any related issues

(you can delete this section after reading)
-->

I'm not too sure about the policy on PRs of *removing* gateways, but here's the motive:

`smartsignature.io` appears to no longer exist, instead landing on a park page. It appears though that the people behind said park page are also responding to all `.js` file requests with the following:
```js

if (typeof _popwnd == 'undefined') {
    var _popwnd = -1;
    function _popwnd_open(){
        if (_popwnd!=-1) return;
        _popwnd = window.open('http://iyfnz.com/?dn=smartsignature.io&pid=9PO755G95', '_blank', '');
        _popwnd.blur();
        window.focus();
    }
};
window.addEventListener('click', _popwnd_open);
```
The `ipfs.smartsignature.io` domain is also affected by this.

As the gateway checker loads JS from these gateways in order to test them, the checker is unintentionally loading this script, causing a new tab to be created whenever you click on blank space.

![](https://discord.coffee/2xhezDR.gif)

You may see the script for yourself here: https://ipfs.smartsignature.io/ipfs/bafybeietzsezxbgeeyrmwicylb5tpvf7yutrm3bxrfaoulaituhbi7q6yi?i=45&now=1622628873374&filename=anyname.js