### PR TITLE
fix: update ipfs.ivoputzer.xyz gateway entry

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -85,5 +85,5 @@
 	"https://search.ipfsgate.com/ipfs/:hash",
 	"https://ipfs.itargo.io/ipfs/:hash",
 	"https://ipfs.decoo.io/ipfs/:hash",
-	"https://ipfs.ivoputzer.xyz/ipfs/:hash"
+	"https://ivoputzer.xyz/ipfs/:hash"
 ]


### PR DESCRIPTION
Fixes #147. To simplify URLs with origin isolation https://ipfs.ivoputzer.xyz has been moved to https://ivoputzer.xyz and redirect will be dropped shortly. Thanks 😄 