### PR TITLE
feat: remove ipfs.foxgirl.dev

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -76,7 +76,6 @@
 	"https://ipfs.xoqq.ch/ipfs/:hash",
 	"https://birds-are-nice.me/ipfs/:hash",
 	"http://natoboram.mynetgear.com:8080/ipfs/:hash",
-	"https://ipfs.foxgirl.dev/ipfs/:hash",
 	"https://video.oneloveipfs.com/ipfs/:hash",
 	"http://ipfs.anonymize.com/ipfs/:hash",
 	"https://ipfs.noormohammed.tech/ipfs/:hash",


### PR DESCRIPTION
<!--
Hello! To ensure this PR is correctly addressed as soon as possible by the IPFS team, please be sure of the following:

IF ADDING A NEW PUBLIC GATEWAY:
- Name your PR in the format `feat: add gateway.address.here`
- Make sure there is no trailing comma in the final gateway in the list at `gateways.json`
- Include a brief description of the gateway to be added (e.g. geographic location, connection speed, available space, etc)

ALL OTHER PULL REQUESTS:
- Name your PR in the format `feat: description`, `fix: description`, `docs: description`, `chore: description`, etc
- Be as complete in your description of changes as possible; if there is an impact on the UI, please include screenshots
- Reference any related issues

(you can delete this section after reading)
-->

Hello! I am the owner and operator of ipfs.foxgirl.dev ([proof](https://ipfs.foxgirl.dev/whoami)).

I'd like to have my gateway removed from the public gateway checker, my network simply cannot keep up with the amount of external traffic I've been getting since my gateway was added to the gateway checker listing in #138. I'm going to keep ipfs.foxgirl.dev up (potentially redirecting to a different public gateway) but I'm going to move everything over to a properly private gateway soon.

Also, I'd appreciate if requests to add any new *.foxgirl.dev gateways to the gateway checker be denied, but I know how annoying it can be to maintain a OSS project, so don't worry about it too much.

Thanks, and have a great night! (or whatever time it is where you are :3)