### PR TITLE
feat: add ipfs-nosub.stibarc.com

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -100,5 +100,6 @@
 	"https://ipfs.slang.cx/ipfs/:hash",
 	"https://ipfs.arching-kaos.com/ipfs/:hash",
 	"https://storry.tv/ipfs/:hash",
-	"https://ipfs.kxv.io/ipfs/:hash"
+	"https://ipfs.kxv.io/ipfs/:hash",
+	"https://ipfs-nosub.stibarc.com/ipfs/:hash"
 ]


### PR DESCRIPTION
Added no-subdomain version of ipfs.stibarc.com, ipfs-nosub.stibarc.com, in case a client didn’t want subdomains and just a regular link