### PR TITLE
feat: add ipfs.namebase.io

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -102,5 +102,6 @@
 	"https://ipfs-nosub.stibarc.com/ipfs/:hash",
 	"https://ipfs.1-2.dev/ipfs/:hash",
 	"https://dweb.eu.org/ipfs/:hash",
-	"https://permaweb.eu.org/ipfs/:hash"
+	"https://permaweb.eu.org/ipfs/:hash",
+	"https://ipfs.namebase.io/ipfs/:hash"
 ]


### PR DESCRIPTION
ipfs.namebase.io is an IPFS gateway created by Namebase that anyone can use to connect their decentralized Handshake domain to their IPFS stuff.

<!--
Hello! To ensure this PR is correctly addressed as soon as possible by the IPFS team, please be sure of the following:

IF ADDING A NEW PUBLIC GATEWAY:
- Name your PR in the format `feat: add gateway.address.here`
- Make sure there is no trailing comma in the final gateway in the list at `gateways.json`
- Include a brief description of the gateway to be added (e.g. geographic location, connection speed, available space, etc)

ALL OTHER PULL REQUESTS:
- Name your PR in the format `feat: description`, `fix: description`, `docs: description`, `chore: description`, etc
- Be as complete in your description of changes as possible; if there is an impact on the UI, please include screenshots
- Reference any related issues

(you can delete this section after reading)
-->
