### PR TITLE
feat: add ipfs.kinematiks.com

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -104,5 +104,6 @@
 	"https://dweb.eu.org/ipfs/:hash",
 	"https://permaweb.eu.org/ipfs/:hash",
 	"https://ipfs.namebase.io/ipfs/:hash",
-	"https://ipfs.tribecap.co/ipfs/:hash"
+	"https://ipfs.tribecap.co/ipfs/:hash",
+	"https://ipfs.kinematiks.com/ipfs/:hash"
 ]


### PR DESCRIPTION
Hello,

I am adding my public gateway. Its hosted in Turkey/Istanbul. I have 100mbit/s unlimited bandwidth connection and hooked 4TB drives in RAID 1 mode. I believe this can be a small contribution to people in Turkey like me running their websites on ipfs. I would be happy if you add my public gateway to the list.
