### PR TITLE
feat: add Meson Network coldcdn.com

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -106,4 +106,5 @@
 	"https://ipfs.namebase.io/ipfs/:hash",
 	"https://ipfs.tribecap.co/ipfs/:hash",
 	"https://ipfs.kinematiks.com/ipfs/:hash"
+	"https://coldcdn.com/api/cdn/4wdhj2/:hash"
 ]


### PR DESCRIPTION
## Meson Network IPFS Gateway
IPFS can be used as storage layer while [meson.network](meson.network) works as a global CDN cache layer

### Origin IPFS link

```
https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
```

### Accelerated link by meson

```
https://coldcdn.com/api/cdn/4wdhj2/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
```
