### PR TITLE
feat: add ipfs.zod.tv

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -103,5 +103,6 @@
 	"https://permaweb.eu.org/ipfs/:hash",
 	"https://ipfs.namebase.io/ipfs/:hash",
 	"https://ipfs.tribecap.co/ipfs/:hash",
-	"https://ipfs.kinematiks.com/ipfs/:hash"
+	"https://ipfs.kinematiks.com/ipfs/:hash",
+        "https://ipfs.zod.tv/ipfs/:hash"
 ]


### PR DESCRIPTION
Finland, Helsinki
1Gbps line (option for 10Gbps if load increases)
2TB NVME (option to expand to 8TB if load increases)

Server uses 100% Renewable Energy - 50% Wind 50% Hydro power
https://www.hetzner.com/assets/Uploads/Oomi-sertifikaatti-tuuli+vesi-Hetzner-2021.pdf

Tests
```
#HTTPS
#IPFS
curl https://ipfs.zod.tv/ipfs/QmejvEPop4D7YUadeGqYWmZxHhLc4JBUCzJJHWMzdcMe2y
ipfs

#IPNS
curl https://ipfs.zod.tv/ipns/en.wikipedia-on-ipfs.org/wiki/Architecture | grep jsConfig
  <script src="../-/mw/jsConfigVars.js"></script>


#HTTP
#IPFS
curl http://ipfs.zod.tv/ipfs/QmejvEPop4D7YUadeGqYWmZxHhLc4JBUCzJJHWMzdcMe2y
ipfs

#IPNS
curl http://ipfs.zod.tv/ipns/en.wikipedia-on-ipfs.org/wiki/Architecture | grep jsConfig
  <script src="../-/mw/jsConfigVars.js"></script>
```