### PR TITLE
chore(deps): bump aegir from 36.1.3 to 36.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@dutu/rate-limiter": "github:dutu/rate-limiter",
+        "@dutu/rate-limiter": "github:dutu/rate-limiter#v1.3.0",
         "url-ponyfill": "^0.5.10"
       },
       "devDependencies": {
-        "aegir": "^36.1.3",
+        "aegir": "^36.2.3",
         "browserslist": "^4.19.3",
         "check-aegir-project": "^1.1.1",
         "cp-cli": "^2.0.0",
@@ -3300,9 +3300,9 @@
       "dev": true
     },
     "node_modules/aegir": {
-      "version": "36.1.3",
-      "resolved": "https://registry.npmjs.org/aegir/-/aegir-36.1.3.tgz",
-      "integrity": "sha512-KE2fC/ysn3esQffSu24oKjWDkrEpUqm6XiOwi0M7QQkrDEy5lfTSrUP5jTZAibcoCqwgODGO3BGNoa+WOGtU8g==",
+      "version": "36.2.3",
+      "resolved": "https://registry.npmjs.org/aegir/-/aegir-36.2.3.tgz",
+      "integrity": "sha512-8xBfUxXK9/jlq4Yj1pVP5Va1nN2L7vE//q02lZ/+VsF0EMjB4oT5n2dpyKxd658FV7kmmstLp8TRg/W/OvIbYg==",
       "dev": true,
       "dependencies": {
         "@electron/get": "^1.12.3",
@@ -3323,7 +3323,6 @@
         "buffer": "^6.0.3",
         "bytes": "^3.1.0",
         "c8": "^7.7.0",
-        "camelcase": "^6.2.0",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "chai-bites": "^0.1.2",
@@ -3364,6 +3363,7 @@
         "ora": "^5.4.0",
         "p-map": "4.0.0",
         "pascalcase": "^1.0.0",
+        "path": "^0.12.7",
         "playwright-test": "^7.0.2",
         "polka": "^0.5.2",
         "premove": "^3.0.1",
@@ -3373,7 +3373,7 @@
         "semantic-release": "^18.0.1",
         "semantic-release-monorepo": "^7.0.5",
         "semver": "^7.3.5",
-        "simple-git": "^2.37.0",
+        "simple-git": "^3.3.0",
         "source-map-support": "^0.5.20",
         "strip-bom": "4.0.0",
         "strip-json-comments": "^3.1.1",
@@ -3384,11 +3384,11 @@
         "yargs": "^17.1.1"
       },
       "bin": {
-        "aegir": "cli.js"
+        "aegir": "src/index.js"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/aegir/node_modules/@types/node": {
@@ -22062,6 +22062,16 @@
         "which": "bin/which"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -25040,14 +25050,14 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
-      "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.4.0.tgz",
+      "integrity": "sha512-sBRdudUc1yvi0xQQPuHXc1L9gTWkRn4hP2bbc7q4BTxR502d3JJAGsDOhrmsBY+wAZAw5JLl82tx55fSWYE65w==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       },
       "funding": {
         "type": "github",
@@ -26580,10 +26590,25 @@
       "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
       "dev": true
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "node_modules/uuid": {
@@ -28247,7 +28272,7 @@
     },
     "@dutu/rate-limiter": {
       "version": "git+ssh://git@github.com/dutu/rate-limiter.git#4199eef4611b4f4661dc09592913aab3cb5c3c46",
-      "from": "@dutu/rate-limiter@github:dutu/rate-limiter",
+      "from": "@dutu/rate-limiter@github:dutu/rate-limiter#v1.3.0",
       "requires": {
         "@babel/polyfill": "^7.12.1"
       }
@@ -29842,9 +29867,9 @@
       "dev": true
     },
     "aegir": {
-      "version": "36.1.3",
-      "resolved": "https://registry.npmjs.org/aegir/-/aegir-36.1.3.tgz",
-      "integrity": "sha512-KE2fC/ysn3esQffSu24oKjWDkrEpUqm6XiOwi0M7QQkrDEy5lfTSrUP5jTZAibcoCqwgODGO3BGNoa+WOGtU8g==",
+      "version": "36.2.3",
+      "resolved": "https://registry.npmjs.org/aegir/-/aegir-36.2.3.tgz",
+      "integrity": "sha512-8xBfUxXK9/jlq4Yj1pVP5Va1nN2L7vE//q02lZ/+VsF0EMjB4oT5n2dpyKxd658FV7kmmstLp8TRg/W/OvIbYg==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.12.3",
@@ -29865,7 +29890,6 @@
         "buffer": "^6.0.3",
         "bytes": "^3.1.0",
         "c8": "^7.7.0",
-        "camelcase": "^6.2.0",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "chai-bites": "^0.1.2",
@@ -29906,6 +29930,7 @@
         "ora": "^5.4.0",
         "p-map": "4.0.0",
         "pascalcase": "^1.0.0",
+        "path": "^0.12.7",
         "playwright-test": "^7.0.2",
         "polka": "^0.5.2",
         "premove": "^3.0.1",
@@ -29915,7 +29940,7 @@
         "semantic-release": "^18.0.1",
         "semantic-release-monorepo": "^7.0.5",
         "semver": "^7.3.5",
-        "simple-git": "^2.37.0",
+        "simple-git": "^3.3.0",
         "source-map-support": "^0.5.20",
         "strip-bom": "4.0.0",
         "strip-json-comments": "^3.1.1",
@@ -44552,6 +44577,16 @@
         }
       }
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -46834,14 +46869,14 @@
       }
     },
     "simple-git": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
-      "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.4.0.tgz",
+      "integrity": "sha512-sBRdudUc1yvi0xQQPuHXc1L9gTWkRn4hP2bbc7q4BTxR502d3JJAGsDOhrmsBY+wAZAw5JLl82tx55fSWYE65w==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       }
     },
     "single-line-log": {
@@ -48065,6 +48100,23 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
       "dev": true
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "url-ponyfill": "^0.5.10"
   },
   "devDependencies": {
-    "aegir": "^36.1.3",
+    "aegir": "^36.2.3",
     "browserslist": "^4.19.3",
     "check-aegir-project": "^1.1.1",
     "cp-cli": "^2.0.0",


### PR DESCRIPTION
This is a follow up to https://github.com/ipfs/aegir/pull/944.

I bumped the version and ran `npm install`.