### PR TITLE
2read.net does not provide public gateway anymore

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -28,8 +28,6 @@
 	"https://ipfs-cdn.aragon.ventures/ipfs/:hash",
 	"https://permaweb.io/ipfs/:hash",
 	"https://ipfs.best-practice.se/ipfs/:hash",
-	"https://2read.net/ipfs/:hash",
-	"https://ipfs.2read.net/ipfs/:hash",
 	"https://storjipfs-gateway.com/ipfs/:hash",
 	"https://ipfs.runfission.com/ipfs/:hash",
 	"https://ipfs.trusti.id/ipfs/:hash",


### PR DESCRIPTION
<!--
Hello! To ensure this PR is correctly addressed as soon as possible by the IPFS team, please be sure of the following:

IF ADDING A NEW PUBLIC GATEWAY:
- Name your PR in the format `feat: add gateway.address.here`
- Make sure there is no trailing comma in the final gateway in the list at `gateways.json`
- Include a brief description of the gateway to be added (e.g. geographic location, connection speed, available space, etc)

ALL OTHER PULL REQUESTS:
- Name your PR in the format `feat: description`, `fix: description`, `docs: description`, `chore: description`, etc
- Be as complete in your description of changes as possible; if there is an impact on the UI, please include screenshots
- Reference any related issues

(you can delete this section after reading)
-->
