### PR TITLE
feat: add gravity.jup.io

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -89,5 +89,6 @@
 	"https://ipfs.tribecap.co/ipfs/:hash",
 	"https://ipfs.kinematiks.com/ipfs/:hash",
 	"https://c4rex.co/ipfs/:hash",
-  	"https://ipfs.zod.tv/ipfs/:hash"
+  	"https://ipfs.zod.tv/ipfs/:hash",
+	"https://gravity.jup.io/ipfs/:hash"
 ]


### PR DESCRIPTION
Jupiter v3.0. Node is currently in datacenter in NE US, multi gbps connection. Available space is currently 10GB @ 90% GC threshold. 
