### PR TITLE
feat: add the Alterdot Network IPFS gateway

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -91,6 +91,6 @@
 	"https://nftstorage.link/ipfs/:hash",
 	"https://gravity.jup.io/ipfs/:hash",
 	"http://fzdqwfb5ml56oadins5jpuhe6ki6bk33umri35p5kt2tue4fpws5efid.onion/ipfs/:hash",
-  "https://tth-ipfs.com/ipfs/:hash",
-  "https://gateway.alterdot.network/ipfs/:hash"
+	"https://tth-ipfs.com/ipfs/:hash",
+	"https://gateway.alterdot.network/ipfs/:hash"
 ]

--- a/src/gateways.json
+++ b/src/gateways.json
@@ -90,5 +90,6 @@
 	"https://ipfs.zod.tv/ipfs/:hash",
 	"https://nftstorage.link/ipfs/:hash",
 	"https://gravity.jup.io/ipfs/:hash",
-	"http://fzdqwfb5ml56oadins5jpuhe6ki6bk33umri35p5kt2tue4fpws5efid.onion/ipfs/:hash"
+	"http://fzdqwfb5ml56oadins5jpuhe6ki6bk33umri35p5kt2tue4fpws5efid.onion/ipfs/:hash",
+	"https://gateway.alterdot.network/ipfs/:hash"
 ]


### PR DESCRIPTION
The Alterdot project is about merging together the two powerful technologies of blockchain and IPFS, therefore we maintain a public IPFS gateway ourselves.

- SSL
- Origin Isolation / Subdomain Resolution