### PR TITLE
feat: add ipfs.litnet.work

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -90,5 +90,6 @@
 	"https://ipfs.zod.tv/ipfs/:hash",
 	"https://nftstorage.link/ipfs/:hash",
 	"https://gravity.jup.io/ipfs/:hash",
+	"https://ipfs.litnet.work/ipfs/:hash",
 	"http://fzdqwfb5ml56oadins5jpuhe6ki6bk33umri35p5kt2tue4fpws5efid.onion/ipfs/:hash"
 ]


### PR DESCRIPTION
Added 1 new public gateway server.
https://ipfs.litnet.work

server geolocation - Mumbai, INDIA. :india:
SSL - strict https
connection speed - 2 gbps (upgrade proposed to 4 gbps)
available space - 60 GB
Access - Read only (at this moment)
