### PR TITLE
Remove Infura

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -2,8 +2,6 @@
 	"https://ipfs.io/ipfs/:hash",
 	"https://dweb.link/ipfs/:hash",
 	"https://gateway.ipfs.io/ipfs/:hash",
-	"https://ipfs.infura.io/ipfs/:hash",
-	"https://infura-ipfs.io/ipfs/:hash",
 	"https://ninetailed.ninja/ipfs/:hash",
 	"https://via0.com/ipfs/:hash",
 	"https://ipfs.eternum.io/ipfs/:hash",


### PR DESCRIPTION
[Infura is deprecating the public gateway](https://blog.infura.io/post/introducing-ipfs-dedicated-gateways#deprecation-of-the-public-api-and-gateway) and returning:

```

HTTP/1.1 400 Bad Request
Content-Length: 68
Content-Type: text/plain; charset=utf-8
Date: Fri, 12 Aug 2022 11:35:28 GMT
Vary: Origin
X-Content-Type-Options: nosniff
X-Robots-Tag: noindex

Public Gateway Is Not Supported Anymore - Setup a Dedicated Gateway
```

Probably time to remove it from the list

<!--
Hello! To ensure this PR is correctly addressed as soon as possible by the IPFS team, please be sure of the following:

IF ADDING A NEW PUBLIC GATEWAY:
- Name your PR in the format `feat: add gateway.address.here`
- Make sure there is no trailing comma in the final gateway in the list at `src/gateways.json`
- Include a brief description of the gateway to be added (e.g. geographic location, connection speed, available space, etc)

ALL OTHER PULL REQUESTS:
- Name your PR in the format `feat: description`, `fix: description`, `docs: description`, `chore: description`, etc
- Be as complete in your description of changes as possible; if there is an impact on the UI, please include screenshots
- Reference any related issues

(you can delete this section after reading)
-->
