### PR TITLE
(fix): Follow Up to 310 - Adding more details to failed trustless test

### DIFF
--- a/src/Trustless.ts
+++ b/src/Trustless.ts
@@ -30,12 +30,16 @@ class Trustless extends CheckBase implements Checkable {
         }
       ))
 
-      if (!trustlessResponseTypesTests.includes(false)) {
+      const failedTests = TRUSTLESS_RESPONSE_TYPES.filter((_result, idx) => !trustlessResponseTypesTests[idx])
+
+      if (failedTests.length === 0) {
         this.tag.win()
       } else {
-        log.debug('The response type did not match the expected type')
-        this.onerror()
-        throw new Error(`URL '${gatewayAndHash} does not support Trustless`)
+        const errorMsg = `URL '${gatewayAndHash} does not support the following Trustless response types: [` +
+          `${failedTests.join(', ')}]`
+
+        log.debug(errorMsg)
+        throw new Error(errorMsg)
       }
     } catch (err) {
       log.error(err)

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
 				<div class="Status" title="Online status: is it possible to read data?" style="cursor: help">Online</div>
         <div class="Cors" title="Allows Cross-Origin Resource Sharing (CORS fetch)"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers" target="_blank">CORS</a></div>
 				<div class="Origin" title="Provides Origin Isolation (Subdomain Gateway)"><a href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">Origin</a></div>
-				<div class="Trustless" title="Supports Trustless Gateway Specification"><a href="https://github.com/ipfs/specs/blob/main/http-gateways/TRUSTLESS_GATEWAY.md" target="_blank">Trustless</a></div>
+				<div class="Trustless" title="Supports Trustless Gateway Specification"><a href="https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval" target="_blank">Block/CAR</a></div>
         <div class="Flag">Country</div>
         <div class="Link">Hostname</div>
 				<div class="Took">ΔT</div>


### PR DESCRIPTION
Follow up to #310.

In this PR:
- Adding failed to tests to the debug messages.