### PR TITLE
feat: add https://ipfs.joaoleitao.org

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -80,5 +80,6 @@
 	"https://4everland.io/ipfs/:hash",
 	"https://ipfs-gateway.cloud/ipfs/:hash",
 	"https://w3s.link/ipfs/:hash",
-	"https://cthd.icu/ipfs/:hash"
+	"https://cthd.icu/ipfs/:hash",
+	"https://ipfs.joaoleitao.org/ipfs/:hash"
 ]


### PR DESCRIPTION
The public gateway is located in Portugal, and it is also being used to assist on measurements conducted in collaboration with the PL Probe Lab.