### PR TITLE
fix: required ci test on ignored paths

### DIFF
--- a/.github/workflows/js-test-and-release-skip.yml
+++ b/.github/workflows/js-test-and-release-skip.yml
@@ -1,0 +1,19 @@
+name: test
+on:
+  push:
+    paths:
+      - "README.md"
+      - "src/gateways.json"
+    branches:
+      - master # with #262 - ${{{ github.default_branch }}}
+  pull_request:
+    paths:
+      - "README.md"
+      - "src/gateways.json"
+    branches:
+      - master # with #262 - ${{{ github.default_branch }}}
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No check necessary"'


### PR DESCRIPTION
Many PRs in this repository are stuck waiting for the `test` workflow even though they have been approved (#321, #323, #326). The problem is that the `test` workflow is skipped for the `gateways.json` and `README.md` files. As per GitHub's own [suggestions](https://github.com/ipfs/public-gateway-checker/blob/master/.github/workflows/js-test-and-release.yml) this PR brings a "fake" workflow with the same name that executes on the paths ignored by the real workflow. This simply passes the test, giving it a green checkmark. 

After this PR, the following should happen:
- `js-test-and-release.yaml` runs except when only `gateways.json` and `README.md` are modified
- `js-test-and-release-skip.yaml` runs when only  `gateways.json` and `README.md` are modified

Then, update all the mentioned PRs to unblock them.