### PR TITLE
Revert "feat: add ipfs.pinksheep.whizzzkid.dev"

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -81,7 +81,6 @@
 	"https://ipfs-gateway.cloud/ipfs/:hash",
 	"https://w3s.link/ipfs/:hash",
 	"https://cthd.icu/ipfs/:hash",
-	"https://ipfs.pinksheep.whizzzkid.dev/ipfs/:hash",
 	"https://ipfs.joaoleitao.org/ipfs/:hash",
 	"https://ipfs.tayfundogdas.me/ipfs/:hash"
 ]


### PR DESCRIPTION
Reverts ipfs/public-gateway-checker#326

Turns out someone loaded a phishing form and reported the site for phishing to google, this is now blocking public gateway checker from testing everything. The cid that's problematic is: `QmaMMPbpjEBqQMfksDTrto1usRpNat9xL6J6ocJ7YNSz3k`

I am not sure what's the best way to block certain routes, is this functionality not built into kubo?

<img width="1246" alt="Screen Shot 2022-11-08 at 10 23 40 PM" src="https://user-images.githubusercontent.com/1895906/200945092-773609a7-485a-4119-8a4c-5f511ced1bce.png">

