### PR TITLE
fix: remove heart

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -52,7 +52,7 @@
 				<div class="Status" title="Online status: is it possible to read data?" style="cursor: help">Online</div>
         <div class="Cors" title="Allows Cross-Origin Resource Sharing (CORS fetch)"><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers" target="_blank">CORS</a></div>
 				<div class="Ipns" title="Allows IPNS Resolution to IPFS Content Addresses"><a href="https://docs.ipfs.tech/concepts/ipns" target="_blank">IPNS</a></div>
-				<div class="Origin" title="Provides Origin Isolation (Subdomain Gateway)"><a href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">Origin</a></div>
+				<div class="Origin" title="Provides Origin Isolation (Subdomain Gateway)"><a href="https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">Origin</a></div>
 				<div class="Trustless" title="Supports Trustless Gateway Specification"><a href="https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval" target="_blank">Block/CAR</a></div>
         <div class="Flag">Country</div>
         <div class="Link">Hostname</div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -99,9 +99,6 @@ div.Node.trustless div.Trustless {
 	margin: 0 1.3em;
 }
 
-div.Node.origin div.Link::after {
-  content: " 💚"
-}
 div.Node:not(.online):not(:first-child) {
   opacity: .5
 }


### PR DESCRIPTION
We were using heart to indicate which gateways support Origin isolation, but since then we've added more  tests and the meaning behind heart is lost.

This PR removes :green_heart:  to reduce noise: it should not distract from columns on the left.