### PR TITLE
chore: removing my gateway for now

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -10,7 +10,6 @@
 	"https://astyanax.io/ipfs/:hash",
 	"https://cf-ipfs.com/ipfs/:hash",
 	"https://ipns.co/ipfs/:hash",
-	"https://ipfs.mrh.io/ipfs/:hash",
 	"https://gateway.originprotocol.com/ipfs/:hash",
 	"https://gateway.pinata.cloud/ipfs/:hash",
 	"https://ipfs.sloppyta.co/ipfs/:hash",


### PR DESCRIPTION
This PR removes mrh.io from the list as I'm not currently maintaining an IPFS gateway.