### PR TITLE
chore: Move the  cookie prompt to the bottom

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,70 +1,72 @@
-body, html {
-	box-sizing: border-box;
-	text-align: center;
+body,
+html {
+  box-sizing: border-box;
+  text-align: center;
 }
 
 div.Stats {
-	display: flex;
-	justify-content: flex-start;
-	align-items: center;
-	margin: 1em auto;
-	width: 95%;
-	max-width: 1024px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin: 1em auto;
+  width: 95%;
+  max-width: 1024px;
 }
 
 div.Stats div.Totals,
 div.Stats div.Gateways {
-	border-radius: 9999px;
-	color: white;
-	font-weight: bold;
-	padding: 0.5em 1em;
-	margin: 0 1em 0 0;
-	font-family: Consolas, monaco, monospace;
+  border-radius: 9999px;
+  color: white;
+  font-weight: bold;
+  padding: 0.5em 1em;
+  margin: 0 1em 0 0;
+  font-family: Consolas, monaco, monospace;
 }
 
 div.Stats div.Gateways {
-	background-color: #0b3a53;
+  background-color: #0b3a53;
 }
 
 div.Stats div.Totals {
-	background-color: #0cb892;
+  background-color: #0cb892;
 }
 
 div.Results {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	margin: 0 auto;
-	width: 100%;
-	max-width: 1024px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1024px;
 }
 
 div.Node {
-	display: flex;
-	justify-content: space-evenly;
-	align-items: center;
-	border-bottom: 1px solid #edf0f4;
-	padding: 0.5em 1em;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  border-bottom: 1px solid #edf0f4;
+  padding: 0.5em 1em;
 }
 
 div.Node:hover {
-	background-color: #edf0f4;
+  background-color: #edf0f4;
 }
 
 
 div.Node div.Link {
-	width: 100%;
-	text-align: left;
-	padding-left: 2em;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+  width: 100%;
+  text-align: left;
+  padding-left: 2em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-div.Node a, div#origin-warning a {
-	text-decoration: none;
-	color: #357edd;
-	white-space: nowrap;
+div.Node a,
+div#origin-warning a {
+  text-decoration: none;
+  color: #357edd;
+  white-space: nowrap;
 }
 
 div.Node div.Status,
@@ -73,30 +75,30 @@ div.Node div.Origin,
 div.Node div.Trustless,
 div.Node div.Ipns,
 div.Node div.Flag {
-	width: 7.2em;
-	text-align: center;
-	margin: 0 0.5em;
-	user-select: none;
+  width: 7.2em;
+  text-align: center;
+  margin: 0 0.5em;
+  user-select: none;
 }
 
 div.Node div.Flag {
-	/* width: 2em; */
-	height: 1em;
-	background-repeat: no-repeat;
-	background-size: contain;
-	background-position: center;
+  /* width: 2em; */
+  height: 1em;
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
   display: inline-block
 }
 
 div.Node div.Took {
-	min-width: 5em;
-	text-align: right;
-	font-size: 80%;
-	font-style: italic;
+  min-width: 5em;
+  text-align: right;
+  font-size: 80%;
+  font-style: italic;
 }
 
 div.Node.trustless div.Trustless {
-	margin: 0 1.3em;
+  margin: 0 1.3em;
 }
 
 div.Node:not(.online):not(:first-child) {
@@ -117,8 +119,10 @@ div#origin-warning p {
   margin-bottom: -.4rem;
 }
 
-div#origin-warning ol, div#origin-warning p, div#origin-warning ul {
-    line-height: 1.7;
+div#origin-warning ol,
+div#origin-warning p,
+div#origin-warning ul {
+  line-height: 1.7;
 }
 
 
@@ -131,18 +135,21 @@ div#checker\.results .Node:nth-child(1) .Link {
  * Should be a color that is not too bright, but still visible
  */
 div.metrics-notification-wrapper {
-  background-color: rgba(246, 248, 251, 1);
+  display: flex;
   justify-content: center;
+  background-color: rgba(246, 248, 251, 1);
   padding: 15px 0;
-  margin: 0 auto;
   width: 100%;
-  max-width: 1024px;
+  position: fixed;
+  bottom: 0;
+  z-index: 1;
 }
 
 div.metrics-notification-container {
   display: flex;
   align-items: center;
   gap: 0.5rem 5rem;
+  width: 80%;
 }
 
 .hidden {
@@ -189,16 +196,17 @@ button#metrics-notification-warning-close {
 
 @media (max-width: 1002px) {
 
-	.metrics-notification-wrapper .metrics-notification-text {
-	  color: rgba(7, 58, 83, 1);
-	  order: 1;
-	  align-self: flex-start;
-	  padding: 0 2rem;
-	}
+  .metrics-notification-wrapper .metrics-notification-text {
+    color: rgba(7, 58, 83, 1);
+    order: 1;
+    align-self: flex-start;
+    padding: 0 2rem;
+  }
 
   .metrics-notification-container {
     display: flex;
     flex-direction: column;
+    width: 90%;
   }
 }
 


### PR DESCRIPTION
# Move cookie prompt to the bottom #341

## Changes made


- Positioned the metrics notification to the bottom as intended
- Change notification wrapper width units from absolute to relative, which helps with responsiveness consistency
- Remove the auto margin since justifying the content to the center takes care of centering the content
- Added a z-index of 1 since the body's content was overlapping the metrics notifications

Before the changes:
![IPFS metrics up](https://user-images.githubusercontent.com/46207472/207458706-8f708d68-bb29-4ee5-9559-67185d04efae.PNG)


After the changes:
![IPFS metrics down](https://user-images.githubusercontent.com/46207472/207458765-95f43d86-5d0d-4625-b612-bb7d62405fce.PNG)

