### PR TITLE
fix: metrics consent prompt location and styling

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
   <link href="styles.css?v=0.4" type="text/css" rel="stylesheet"/>
 </head>
 <body id="checker" class="sans-serif charcoal bg-snow-muted">
-  <div class="hidden js-metrics-notification-decline-warning metrics-notification-wrapper">
+  <div class="hidden js-metrics-notification-decline-warning metrics-notification-wrapper bg-navy bt bw1 border-aqua">
     <div class="metrics-notification-container">
       <span id="metrics-notification-decline-warning" class="metrics-notification-text">
         We will limit collection of metrics to only necessary features, 'sessions' and 'views'. See <a href="https://support.count.ly/hc/en-us/articles/360037441932-Web-analytics-JavaScript-#features-for-consent">Countly's group_features</a> for more information.
@@ -23,12 +23,13 @@
       </div>
     </div>
   </div>
-  <div class="hidden js-metrics-notification metrics-notification-wrapper">
+  <div class="hidden js-metrics-notification metrics-notification-wrapper bg-navy bt bw1 border-aqua">
+    <div class="metrics-notification-spacer"></div>
     <div class="metrics-notification-container">
       <span class="metrics-notification-text">We're collecting <a href="https://github.com/ipfs/ipfs-gui/issues/125">web-vitals, pageview, and other metrics</a> in order to improve and prioritize our work on IPFS and its public gateways.
         Please consent to the collection of these metrics to assist in our efforts!</span>
       <div class="metrics-notification-buttons">
-        <button id="metrics-notification-accept" class="js-metrics-notification-accept">☑&nbsp;Agree</button>
+        <button id="metrics-notification-accept" class="js-metrics-notification-accept">Allow</button>
         <button id="metrics-notification-decline" class="js-metrics-notification-decline">Decline</button>
       </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,7 @@
     </div>
   </header>
 
-  <div class="ph4-l pt4-l">
+  <div class="ph4-l pt4-l overflow-hidden">
     <div id="origin-warning" class="f5 pa2 tl">
       <p>SECURITY NOTES</p>
       <ul class="pl3">

--- a/src/index.html
+++ b/src/index.html
@@ -13,27 +13,6 @@
   <link href="styles.css?v=0.4" type="text/css" rel="stylesheet"/>
 </head>
 <body id="checker" class="sans-serif charcoal bg-snow-muted">
-  <div class="hidden js-metrics-notification-decline-warning metrics-notification-wrapper bg-navy bt bw1 border-aqua">
-    <div class="metrics-notification-container">
-      <span id="metrics-notification-decline-warning" class="metrics-notification-text">
-        We will limit collection of metrics to only necessary features, 'sessions' and 'views'. See <a href="https://support.count.ly/hc/en-us/articles/360037441932-Web-analytics-JavaScript-#features-for-consent">Countly's group_features</a> for more information.
-      </span>
-      <div class="metrics-notification-buttons">
-        <button id="metrics-notification-warning-close" class="js-metrics-notification-warning-close">✕&nbsp;Close</button>
-      </div>
-    </div>
-  </div>
-  <div class="hidden js-metrics-notification metrics-notification-wrapper bg-navy bt bw1 border-aqua">
-    <div class="metrics-notification-spacer"></div>
-    <div class="metrics-notification-container">
-      <span class="metrics-notification-text">We're collecting <a href="https://github.com/ipfs/ipfs-gui/issues/125">web-vitals, pageview, and other metrics</a> in order to improve and prioritize our work on IPFS and its public gateways.
-        Please consent to the collection of these metrics to assist in our efforts!</span>
-      <div class="metrics-notification-buttons">
-        <button id="metrics-notification-accept" class="js-metrics-notification-accept">Allow</button>
-        <button id="metrics-notification-decline" class="js-metrics-notification-decline">Decline</button>
-      </div>
-    </div>
-  </div>
   <header class='flex-l items-center pa3 bg-navy bb bw3 border-aqua tc tl-l'>
     <a href="https://ipfs.io" target="_blank" title="ipfs.io" class='flex-none v-mid'>
       <img src="https://ipfs.io/ipfs/QmTqZhR6f7jzdhLgPArDPnsbZpvvgxzCZycXK7ywkLxSyU?filename=ipfs-logo.3ea91a2f.svg" alt="IPFS" height="50px" width="117.5px" />
@@ -66,24 +45,7 @@
         </li>
       </ul>
     </div>
-    <div id="checker.stats" class="Stats monospace f6">
-      <button class="cookieConsentToggle js-cookie-banner-toggle" aria-label="Edit cookie settings">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-          <path d="M510.52 255.82c-69.97-.85-126.47-57.69-126.47-127.86-70.17
-            0-127-56.49-127.86-126.45-27.26-4.14-55.13.3-79.72 12.82l-69.13
-            35.22a132.221 132.221 0 0 0-57.79 57.81l-35.1 68.88a132.645 132.645 0 0
-            0-12.82 80.95l12.08 76.27a132.521 132.521 0 0 0 37.16 72.96l54.77
-            54.76a132.036 132.036 0 0 0 72.71 37.06l76.71 12.15c27.51 4.36 55.7-.11
-            80.53-12.76l69.13-35.21a132.273 132.273 0 0 0
-            57.79-57.81l35.1-68.88c12.56-24.64 17.01-52.58 12.91-79.91zM176
-            368c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32
-            32zm32-160c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33
-            32-32 32zm160 128c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32
-            32-14.33 32-32 32z"
-          />
-        </svg>
-      </button>
-    </div>
+    <div id="checker.stats" class="Stats monospace f6"></div>
     <div id="checker.results" class="Results monospace f6">
       <div class="Node Header">
         <div class="Status" title="Online status: is it possible to read data?" style="cursor: help">Online</div>
@@ -96,7 +58,45 @@
         <div class="Took">ΔT</div>
       </div>
     </div>
+  <div class="hidden js-metrics-notification-decline-warning metrics-notification-wrapper bg-navy bt bw1 border-aqua">
+    <div class="metrics-notification-spacer"></div>
+    <div class="metrics-notification-container">
+      <span id="metrics-notification-decline-warning" class="metrics-notification-text">
+        We will limit collection of metrics to only necessary features, 'sessions' and 'views'. See <a href="https://support.count.ly/hc/en-us/articles/360037441932-Web-analytics-JavaScript-#features-for-consent">Countly's group_features</a> for more information.
+      </span>
+      <div class="metrics-notification-buttons">
+        <button id="metrics-notification-warning-close" class="js-metrics-notification-warning-close">✕&nbsp;Close</button>
+      </div>
+    </div>
   </div>
+  <div class="hidden js-metrics-notification metrics-notification-wrapper bg-navy bt bw1 border-aqua">
+    <div class="metrics-notification-spacer"></div>
+    <div class="metrics-notification-container">
+      <span class="metrics-notification-text">We're collecting <a href="https://github.com/ipfs/ipfs-gui/issues/125">web-vitals, pageview, and other metrics</a> in order to improve and prioritize our work on IPFS and its public gateways.
+        Please consent to the collection of these metrics to assist in our efforts!</span>
+      <div class="metrics-notification-buttons">
+        <button id="metrics-notification-accept" class="js-metrics-notification-accept">Allow</button>
+        <button id="metrics-notification-decline" class="js-metrics-notification-decline">Decline</button>
+      </div>
+    </div>
+  </div>
+  <button class="cookieConsentToggle js-cookie-banner-toggle" aria-label="Edit cookie settings">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+      <path d="M510.52 255.82c-69.97-.85-126.47-57.69-126.47-127.86-70.17
+        0-127-56.49-127.86-126.45-27.26-4.14-55.13.3-79.72 12.82l-69.13
+        35.22a132.221 132.221 0 0 0-57.79 57.81l-35.1 68.88a132.645 132.645 0 0
+        0-12.82 80.95l12.08 76.27a132.521 132.521 0 0 0 37.16 72.96l54.77
+        54.76a132.036 132.036 0 0 0 72.71 37.06l76.71 12.15c27.51 4.36 55.7-.11
+        80.53-12.76l69.13-35.21a132.273 132.273 0 0 0
+        57.79-57.81l35.1-68.88c12.56-24.64 17.01-52.58 12.91-79.91zM176
+        368c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32
+        32zm32-160c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33
+        32-32 32zm160 128c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32
+        32-14.33 32-32 32z"
+      />
+    </svg>
+  </button>
+</div>
 <script src="./index.min.js?v=0.4"></script>
 </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -175,6 +175,7 @@ div.metrics-notification-wrapper .metrics-notification-buttons {
   align-content: center;
   display: flex;
   gap: 1rem;
+  padding-right: 15px;
 }
 
 div.metrics-notification-wrapper a {
@@ -190,7 +191,7 @@ div.metrics-notification-wrapper button {
   vertical-align: center;
   text-align: center;
   border-radius: 5px;
-  font-weight: bold;
+  font-weight: 600;
   padding: 8px;
 }
 
@@ -206,7 +207,7 @@ button#metrics-notification-warning-close {
 }
 
 .metrics-notification-spacer {
-  width: 70px;
+  width: 80px;
 }
 
 @media (max-width: 1002px) {
@@ -217,11 +218,22 @@ button#metrics-notification-warning-close {
 	  align-self: flex-start;
 	  padding: 0 2rem;
     text-align: left;
+    font-size: 15px;
 	}
 
-  .metrics-notification-container {
+  div.metrics-notification-container {
     display: flex;
     flex-direction: column;
+    gap: 0.75rem 5rem;
+  }
+
+  .metrics-notification-spacer {
+    width: 0;
+  }
+
+  div.metrics-notification-wrapper .metrics-notification-buttons {
+    font-size: 15px;
+    padding-right: 0;
   }
 }
 
@@ -241,9 +253,9 @@ button#metrics-notification-warning-close {
   opacity: 1;
   z-index: 99980;
   cursor: pointer;
-  margin: 0 1em 0 0;
+  margin: 0;
   position: fixed;
-  bottom: 15px;
+  bottom: 12px;
   left: 15px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -131,17 +131,22 @@ div#checker\.results .Node:nth-child(1) .Link {
  * Should be a color that is not too bright, but still visible
  */
 div.metrics-notification-wrapper {
-  background-color: rgba(246, 248, 251, 1);
   justify-content: center;
-  padding: 15px 0;
-  margin: 0 auto;
+  display: flex;
   width: 100%;
-  max-width: 1024px;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
 }
 
 div.metrics-notification-container {
+  width: 100%;
   display: flex;
   align-items: center;
+  justify-content: center;
+  max-width: 1024px;
+  padding: 15px 0;
   gap: 0.5rem 5rem;
 }
 
@@ -149,10 +154,18 @@ div.metrics-notification-container {
   display: none;
 }
 
+.hidden.metrics-notification-wrapper {
+  opacity: 0;
+  position: relative;
+  display: none;
+}
+
+
 div.metrics-notification-wrapper .metrics-notification-text {
-  color: rgba(7, 58, 83, 1);
-  order: 1;
+  color:rgba(246, 248, 251, 1);
+  order: 2;
   align-self: flex-start;
+  text-align: left;
 }
 
 div.metrics-notification-wrapper .metrics-notification-buttons {
@@ -176,10 +189,15 @@ div.metrics-notification-wrapper button {
   align-content: center;
   vertical-align: center;
   text-align: center;
+  border-radius: 5px;
+  font-weight: bold;
+  padding: 8px;
 }
 
 .metrics-notification-wrapper button#metrics-notification-accept {
   border: 1pt solid rgba(107, 196, 206, 1);
+  background-color: rgba(107, 196, 206, 1);
+  color:rgba(246, 248, 251, 1);
 }
 
 button#metrics-notification-warning-close {
@@ -187,13 +205,18 @@ button#metrics-notification-warning-close {
   /* color: rgba(7, 58, 83, 1); */
 }
 
+.metrics-notification-spacer {
+  width: 70px;
+}
+
 @media (max-width: 1002px) {
 
 	.metrics-notification-wrapper .metrics-notification-text {
-	  color: rgba(7, 58, 83, 1);
-	  order: 1;
+	  color:rgba(246, 248, 251, 1);
+	  order: 2;
 	  align-self: flex-start;
 	  padding: 0 2rem;
+    text-align: left;
 	}
 
   .metrics-notification-container {
@@ -219,6 +242,9 @@ button#metrics-notification-warning-close {
   z-index: 99980;
   cursor: pointer;
   margin: 0 1em 0 0;
+  position: fixed;
+  bottom: 15px;
+  left: 15px;
 }
 
 .cookieConsentToggle:disabled {


### PR DESCRIPTION
Fixes #341 and addresses #340 

- Moved cookie toggle button to lower left
- Updated metric consent prompt to be fixed at bottom of page
- Updated styles of metric consent prompt (interim fix until new modal updates are added in #340)
<img width="1273" alt="Screen Shot 2022-12-19 at 2 02 47 PM" src="https://user-images.githubusercontent.com/10619673/208559560-1c6b543c-feb8-48df-b9b2-6b1e698893bf.png">

https://user-images.githubusercontent.com/10619673/208559656-0ffbd34a-c5d3-4ed4-82bf-149696d4ba54.mov

