### PR TITLE
Added https://ipfs.czip.it public gateway

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -82,5 +82,6 @@
 	"https://cthd.icu/ipfs/:hash",
 	"https://ipfs.joaoleitao.org/ipfs/:hash",
 	"https://ipfs.tayfundogdas.me/ipfs/:hash",
-	"https://ipfs.jpu.jp/ipfs/:hash"
+	"https://ipfs.jpu.jp/ipfs/:hash",
+	"https://ipfs.czip.it/ipfs/:hash"	
 ]


### PR DESCRIPTION
feat: add ipfs.czip.it
location: Italy
av. space: 5 GB

