### PR TITLE
feat: add ipfs.soul-network.com

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -83,5 +83,6 @@
 	"https://ipfs.joaoleitao.org/ipfs/:hash",
 	"https://ipfs.tayfundogdas.me/ipfs/:hash",
 	"https://ipfs.jpu.jp/ipfs/:hash",
-	"https://ipfs.czip.it/ipfs/:hash"	
+	"https://ipfs.czip.it/ipfs/:hash",
+	"https://ipfs.soul-network.com"
 ]

--- a/src/gateways.json
+++ b/src/gateways.json
@@ -84,5 +84,5 @@
 	"https://ipfs.tayfundogdas.me/ipfs/:hash",
 	"https://ipfs.jpu.jp/ipfs/:hash",
 	"https://ipfs.czip.it/ipfs/:hash",
-	"https://ipfs.soul-network.com"
+	"https://ipfs.soul-network.com/ipfs/:hash"
 ]


### PR DESCRIPTION
Soul is a new platform for censorship-resistant blogging. Each article is posted on the IPFS network (or at least pinned locally).

This IPFS instance is hosted on a Vultr VPS based in New Jersey, United States. Current available space is set to 80GB but I definitely plan on scaling in the future if demand increases.

<!--
Hello! To ensure this PR is correctly addressed as soon as possible by the IPFS team, please be sure of the following:

IF ADDING A NEW PUBLIC GATEWAY:
- Name your PR in the format `feat: add gateway.address.here`
- Make sure there is no trailing comma in the final gateway in the list at `src/gateways.json`
- Include a brief description of the gateway to be added (e.g. geographic location, connection speed, available space, etc)

ALL OTHER PULL REQUESTS:
- Name your PR in the format `feat: description`, `fix: description`, `docs: description`, `chore: description`, etc
- Be as complete in your description of changes as possible; if there is an impact on the UI, please include screenshots
- Reference any related issues

(you can delete this section after reading)
-->
