### PR TITLE
feat: Deleted https://ipfs.czip.it

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -82,7 +82,6 @@
 	"https://cthd.icu/ipfs/:hash",
 	"https://ipfs.joaoleitao.org/ipfs/:hash",
 	"https://ipfs.tayfundogdas.me/ipfs/:hash",
-	"https://ipfs.jpu.jp/ipfs/:hash",
-	"https://ipfs.czip.it/ipfs/:hash",
+	"https://ipfs.jpu.jp/ipfs/:hash",	
 	"https://ipfs.soul-network.com/ipfs/:hash"
 ]


### PR DESCRIPTION
Removed https://ipfs.czip.it because it's not working anymore (too much abuse reports from host).

