### PR TITLE
fix: :rewind: Reverting #323: ipfs.joaoleitao.org

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -80,7 +80,6 @@
 	"https://ipfs-gateway.cloud/ipfs/:hash",
 	"https://w3s.link/ipfs/:hash",
 	"https://cthd.icu/ipfs/:hash",
-	"https://ipfs.joaoleitao.org/ipfs/:hash",
 	"https://ipfs.tayfundogdas.me/ipfs/:hash",
 	"https://ipfs.jpu.jp/ipfs/:hash",
 	"https://ipfs.czip.it/ipfs/:hash",


### PR DESCRIPTION
Reverts: #323
Closes: #392

Looks like the gateway checker is showing the red-screen from google deceptive check. Just wondering if there's a long-term fix for this 🤔.