### PR TITLE
Update gateways.json

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -75,7 +75,6 @@
 	"https://tth-ipfs.com/ipfs/:hash",
 	"https://ipfs.chisdealhd.co.uk/ipfs/:hash",
 	"https://ipfs.alloyxuast.tk/ipfs/:hash",
-	"https://ipfs.litnet.work/ipfs/:hash",
 	"https://4everland.io/ipfs/:hash",
 	"https://ipfs-gateway.cloud/ipfs/:hash",
 	"https://w3s.link/ipfs/:hash",


### PR DESCRIPTION
Removing ipfs.litnet.work gateway. Can't manage such loads of phishing reports and domain takedown warnings.

