### PR TITLE
remove the c4rex.co gateway as its currently flagged as unsafe in chrome

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -68,7 +68,6 @@
 	"https://ipfs.namebase.io/ipfs/:hash",
 	"https://ipfs.tribecap.co/ipfs/:hash",
 	"https://ipfs.kinematiks.com/ipfs/:hash",
-	"https://c4rex.co/ipfs/:hash",
 	"https://nftstorage.link/ipfs/:hash",
 	"https://gravity.jup.io/ipfs/:hash",
 	"http://fzdqwfb5ml56oadins5jpuhe6ki6bk33umri35p5kt2tue4fpws5efid.onion/ipfs/:hash",


### PR DESCRIPTION
while c4rex.co is included as a gateway to check, chrome's red page of death fires on https://ipfs.github.io/public-gateway-checker/ when a network request is sent to c4rex.co to check its status

![image](https://github.com/ipfs/public-gateway-checker/assets/1041265/2e5566b8-f008-464b-ae97-4ec89cc41bbe)
