### PR TITLE
feat: rename starbase.gw3.io to gw3.io

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -16,6 +16,7 @@
 	"https://ipfs.busy.org/ipfs/:hash",
 	"https://ipfs.greyh.at/ipfs/:hash",
 	"https://gateway.serph.network/ipfs/:hash",
+	"https://gw3.io/ipfs/:hash",
 	"https://jorropo.net/ipfs/:hash",
 	"https://ipfs.fooock.com/ipfs/:hash",
 	"https://cdn.cwinfo.net/ipfs/:hash",
@@ -80,6 +81,5 @@
 	"https://cthd.icu/ipfs/:hash",
 	"https://ipfs.tayfundogdas.me/ipfs/:hash",
 	"https://ipfs.jpu.jp/ipfs/:hash",	
-	"https://ipfs.soul-network.com/ipfs/:hash",
-	"https://starbase.gw3.io/ipfs/:hash"
+	"https://ipfs.soul-network.com/ipfs/:hash"
 ]


### PR DESCRIPTION
In a recent meeting with Stef from the Filecoin Foundation, we were advised to rebrand our gateway for improved visibility in the IPFS ecosystem. Therefore, we've changed our gateway from https://starbase.gw3.io to the more straightforward https://gw3.io.

Please review this change in our PR. Looking forward to your feedback.