### PR TITLE
feat: add ipfs2.eth.limo

### DIFF
--- a/src/gateways.json
+++ b/src/gateways.json
@@ -81,5 +81,6 @@
 	"https://cthd.icu/ipfs/:hash",
 	"https://ipfs.tayfundogdas.me/ipfs/:hash",
 	"https://ipfs.jpu.jp/ipfs/:hash",	
-	"https://ipfs.soul-network.com/ipfs/:hash"
+	"https://ipfs.soul-network.com/ipfs/:hash",
+	"https://:hash.ipfs2.eth.limo"
 ]


### PR DESCRIPTION
Location: N/A
Connection Speed: N/A
Available Space: N/A

* `N/A` as it's web3 service using public ENS gateways. 

resolves #408 issue

<!--
Hello! To ensure this PR is correctly addressed as soon as possible by the IPFS team, please be sure of the following:

IF ADDING A NEW PUBLIC GATEWAY:
- Name your PR in the format `feat: add gateway.address.here`
- Make sure there is no trailing comma in the final gateway in the list at `src/gateways.json`
- Include a brief description of the gateway to be added (e.g. geographic location, connection speed, available space, etc)

ALL OTHER PULL REQUESTS:
- Name your PR in the format `feat: description`, `fix: description`, `docs: description`, `chore: description`, etc
- Be as complete in your description of changes as possible; if there is an impact on the UI, please include screenshots
- Reference any related issues

(you can delete this section after reading)
-->
