### PR TITLE
chore: update eslint-config-ipfs and fix lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "browserslist": "^4.21.4",
         "check-aegir-project": "^1.1.1",
         "cp-cli": "^2.0.0",
-        "eslint-config-ipfs": "^3.1.2",
+        "eslint-config-ipfs": "^4.0.3",
         "eslint-plugin-compat": "^4.0.2",
         "fetch-ponyfill": "^7.1.0",
         "ipfs": "^0.65.0",
@@ -2767,6 +2767,42 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -5958,6 +5994,12 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.11",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.11.tgz",
@@ -6023,17 +6065,19 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.9.tgz",
+      "integrity": "sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/type-utils": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/type-utils": "5.59.9",
+        "@typescript-eslint/utils": "5.59.9",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
-        "regexpp": "^3.2.0",
+        "natural-compare-lite": "^1.4.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
@@ -6052,6 +6096,49 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+      "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
+      "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
@@ -6106,14 +6193,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-      "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.9.tgz",
+      "integrity": "sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6132,54 +6219,14 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+      "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6204,30 +6251,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -6287,13 +6310,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.9.tgz",
+      "integrity": "sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.59.9",
+        "@typescript-eslint/utils": "5.59.9",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -6313,11 +6336,15 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+      "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
       "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9"
+      },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6326,19 +6353,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
+      "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6347,27 +6375,8 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
@@ -6387,19 +6396,82 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
+      "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
+      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6549,6 +6621,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
+      "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.9",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -7013,6 +7114,73 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/aegir/node_modules/eslint-config-ipfs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-ipfs/-/eslint-config-ipfs-3.1.7.tgz",
+      "integrity": "sha512-/AWBOKU8GbRvStJkOliNgI0g45ZMLdKfLrZwraa3SgObl0KivB1MMPkmcDgPA0SEqz9i8ufd/dwF95ujXsO0MQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.23.0",
+        "@typescript-eslint/parser": "^5.23.0",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-config-standard-with-typescript": "^27.0.1",
+        "eslint-plugin-etc": "^2.0.2",
+        "eslint-plugin-import": "^2.18.0",
+        "eslint-plugin-jsdoc": "^39.2.9",
+        "eslint-plugin-no-only-tests": "^3.0.0",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/aegir/node_modules/eslint-config-ipfs/node_modules/eslint-config-standard-with-typescript": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-27.0.1.tgz",
+      "integrity": "sha512-jJVyJldqqiCu3uSA/FP0x9jCDMG+Bbl73twTSnp0aysumJrz4iaVqLl+tGgmPrv0R829GVs117Nmn47M1DDDXA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint-config-standard": "17.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/aegir/node_modules/eslint-config-standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
       }
     },
     "node_modules/aegir/node_modules/execa": {
@@ -7817,6 +7985,15 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
@@ -12036,21 +12213,25 @@
       }
     },
     "node_modules/eslint-config-ipfs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-ipfs/-/eslint-config-ipfs-3.1.2.tgz",
-      "integrity": "sha512-oyALQsHUjn4Y5tZWO1FXspFEFQ1V06h+5bJdnn01bLi6+ftAXLNDb4YMJVae+D/UmHT4TFN2Dr0gPS4fACkNCg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-ipfs/-/eslint-config-ipfs-4.0.3.tgz",
+      "integrity": "sha512-u3k7rPVSveWKKlIKGmYXMskKzWOs1hplX4hk1+fXKUxb9lh+x44LrJI5/Yqaip+7pHhJ7j47jZQKJOMqAuHViA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
         "eslint-config-standard": "^17.0.0",
-        "eslint-config-standard-with-typescript": "^23.0.0",
+        "eslint-config-standard-with-typescript": "^34.0.1",
         "eslint-plugin-etc": "^2.0.2",
         "eslint-plugin-import": "^2.18.0",
-        "eslint-plugin-jsdoc": "^39.2.9",
+        "eslint-plugin-jsdoc": "^43.1.1",
         "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -12058,7 +12239,131 @@
         }
       }
     },
+    "node_modules/eslint-config-ipfs/node_modules/@es-joy/jsdoccomment": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.38.0.tgz",
+      "integrity": "sha512-TFac4Bnv0ZYNkEeDnOWHQhaS1elWlvOCQxH06iHeu5iffs+hCaLVIZJwF+FqksQi68R4i66Pu+4DfFGvble+Uw==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/eslint-config-ipfs/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-ipfs/node_modules/eslint-plugin-jsdoc": {
+      "version": "43.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.2.0.tgz",
+      "integrity": "sha512-Hst7XUfqh28UmPD52oTXmjaRN3d0KrmOZdgtp4h9/VHUJD3Evoo82ZGXi1TtRDWgWhvqDIRI63O49H0eH7NrZQ==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.38.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "semver": "^7.5.0",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-config-ipfs/node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/eslint-config-ipfs/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-config-standard": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
+      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
+        "eslint-plugin-promise": "^6.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard-with-typescript": {
+      "version": "34.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-34.0.1.tgz",
+      "integrity": "sha512-J7WvZeLtd0Vr9F+v4dZbqJCLD16cbIy4U+alJMq4MiXdpipdBM3U5NkXaGUjePc4sb1ZE01U9g6VuTBpHHz1fg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^5.43.0",
+        "eslint-config-standard": "17.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.43.0",
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-config-standard-with-typescript/node_modules/eslint-config-standard": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
       "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
@@ -12082,24 +12387,6 @@
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-n": "^15.0.0",
         "eslint-plugin-promise": "^6.0.0"
-      }
-    },
-    "node_modules/eslint-config-standard-with-typescript": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-23.0.0.tgz",
-      "integrity": "sha512-iaaWifImn37Z1OXbNW1es7KI+S7D408F9ys0bpaQf2temeBWlvb0Nc5qHkOgYaRb5QxTZT32GGeN1gtswASOXA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint-config-standard": "17.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "eslint": "^8.0.1",
-        "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-n": "^15.0.0",
-        "eslint-plugin-promise": "^6.0.0",
-        "typescript": "*"
       }
     },
     "node_modules/eslint-etc": {
@@ -12392,9 +12679,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.3.0.tgz",
-      "integrity": "sha512-IyzPnEWHypCWasDpxeJnim60jhlumbmq0pubL6IOcnk8u2y53s5QfT8JnXy7skjHJ44yWHRb11PLtDHuu1kg/Q==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -12402,10 +12689,10 @@
         "eslint-plugin-es": "^4.1.0",
         "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "is-core-module": "^2.10.0",
+        "is-core-module": "^2.11.0",
         "minimatch": "^3.1.2",
         "resolve": "^1.22.1",
-        "semver": "^7.3.7"
+        "semver": "^7.3.8"
       },
       "engines": {
         "node": ">=12.22.0"
@@ -12493,9 +12780,9 @@
       }
     },
     "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -16117,9 +16404,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -20091,6 +20378,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "node_modules/ndjson": {
@@ -32692,6 +32985,29 @@
       "dev": true,
       "optional": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+          "dev": true
+        }
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
@@ -35383,6 +35699,12 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
     "@types/sinon": {
       "version": "10.0.11",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.11.tgz",
@@ -35448,21 +35770,49 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.9.tgz",
+      "integrity": "sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/type-utils": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/type-utils": "5.59.9",
+        "@typescript-eslint/utils": "5.59.9",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
-        "regexpp": "^3.2.0",
+        "natural-compare-lite": "^1.4.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.59.9",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+          "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.59.9",
+            "@typescript-eslint/visitor-keys": "5.59.9"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.59.9",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
+          "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.2.0",
+            "@types/json-schema": "^7.0.9",
+            "@types/semver": "^7.3.12",
+            "@typescript-eslint/scope-manager": "5.59.9",
+            "@typescript-eslint/types": "5.59.9",
+            "@typescript-eslint/typescript-estree": "5.59.9",
+            "eslint-scope": "^5.1.1",
+            "semver": "^7.3.7"
+          }
+        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -35493,46 +35843,25 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-      "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.9.tgz",
+      "integrity": "sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
         "debug": "^4.3.4"
       },
       "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "5.39.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-          "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.39.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-          "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+        "@typescript-eslint/scope-manager": {
+          "version": "5.59.9",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+          "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.39.0",
-            "@typescript-eslint/visitor-keys": "5.39.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.39.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-          "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.39.0",
-            "eslint-visitor-keys": "^3.3.0"
+            "@typescript-eslint/types": "5.59.9",
+            "@typescript-eslint/visitor-keys": "5.59.9"
           }
         },
         "debug": {
@@ -35542,21 +35871,6 @@
           "dev": true,
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -35596,46 +35910,41 @@
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.9.tgz",
+      "integrity": "sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.59.9",
+        "@typescript-eslint/utils": "5.59.9",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "5.39.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-          "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.39.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-          "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+        "@typescript-eslint/scope-manager": {
+          "version": "5.59.9",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+          "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.39.0",
-            "@typescript-eslint/visitor-keys": "5.39.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
+            "@typescript-eslint/types": "5.59.9",
+            "@typescript-eslint/visitor-keys": "5.59.9"
           }
         },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.39.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-          "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+        "@typescript-eslint/utils": {
+          "version": "5.59.9",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
+          "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.39.0",
-            "eslint-visitor-keys": "^3.3.0"
+            "@eslint-community/eslint-utils": "^4.2.0",
+            "@types/json-schema": "^7.0.9",
+            "@types/semver": "^7.3.12",
+            "@typescript-eslint/scope-manager": "5.59.9",
+            "@typescript-eslint/types": "5.59.9",
+            "@typescript-eslint/typescript-estree": "5.59.9",
+            "eslint-scope": "^5.1.1",
+            "semver": "^7.3.7"
           }
         },
         "debug": {
@@ -35647,16 +35956,51 @@
             "ms": "2.1.2"
           }
         },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
+        "semver": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
+      "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
+      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -35743,6 +36087,24 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
+      "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.9",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+          "dev": true
         }
       }
     },
@@ -36144,6 +36506,43 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
           "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
           "dev": true
+        },
+        "eslint-config-ipfs": {
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/eslint-config-ipfs/-/eslint-config-ipfs-3.1.7.tgz",
+          "integrity": "sha512-/AWBOKU8GbRvStJkOliNgI0g45ZMLdKfLrZwraa3SgObl0KivB1MMPkmcDgPA0SEqz9i8ufd/dwF95ujXsO0MQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/eslint-plugin": "^5.23.0",
+            "@typescript-eslint/parser": "^5.23.0",
+            "eslint-config-standard": "^17.0.0",
+            "eslint-config-standard-with-typescript": "^27.0.1",
+            "eslint-plugin-etc": "^2.0.2",
+            "eslint-plugin-import": "^2.18.0",
+            "eslint-plugin-jsdoc": "^39.2.9",
+            "eslint-plugin-no-only-tests": "^3.0.0",
+            "eslint-plugin-node": "^11.1.0",
+            "eslint-plugin-promise": "^6.0.0"
+          },
+          "dependencies": {
+            "eslint-config-standard-with-typescript": {
+              "version": "27.0.1",
+              "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-27.0.1.tgz",
+              "integrity": "sha512-jJVyJldqqiCu3uSA/FP0x9jCDMG+Bbl73twTSnp0aysumJrz4iaVqLl+tGgmPrv0R829GVs117Nmn47M1DDDXA==",
+              "dev": true,
+              "requires": {
+                "@typescript-eslint/parser": "^5.0.0",
+                "eslint-config-standard": "17.0.0"
+              }
+            }
+          }
+        },
+        "eslint-config-standard": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+          "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+          "dev": true,
+          "requires": {}
         },
         "execa": {
           "version": "7.0.0",
@@ -36697,6 +37096,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
       "dev": true
     },
     "are-we-there-yet": {
@@ -40038,38 +40443,100 @@
       }
     },
     "eslint-config-ipfs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-ipfs/-/eslint-config-ipfs-3.1.2.tgz",
-      "integrity": "sha512-oyALQsHUjn4Y5tZWO1FXspFEFQ1V06h+5bJdnn01bLi6+ftAXLNDb4YMJVae+D/UmHT4TFN2Dr0gPS4fACkNCg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-ipfs/-/eslint-config-ipfs-4.0.3.tgz",
+      "integrity": "sha512-u3k7rPVSveWKKlIKGmYXMskKzWOs1hplX4hk1+fXKUxb9lh+x44LrJI5/Yqaip+7pHhJ7j47jZQKJOMqAuHViA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
         "eslint-config-standard": "^17.0.0",
-        "eslint-config-standard-with-typescript": "^23.0.0",
+        "eslint-config-standard-with-typescript": "^34.0.1",
         "eslint-plugin-etc": "^2.0.2",
         "eslint-plugin-import": "^2.18.0",
-        "eslint-plugin-jsdoc": "^39.2.9",
+        "eslint-plugin-jsdoc": "^43.1.1",
         "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0"
+      },
+      "dependencies": {
+        "@es-joy/jsdoccomment": {
+          "version": "0.38.0",
+          "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.38.0.tgz",
+          "integrity": "sha512-TFac4Bnv0ZYNkEeDnOWHQhaS1elWlvOCQxH06iHeu5iffs+hCaLVIZJwF+FqksQi68R4i66Pu+4DfFGvble+Uw==",
+          "dev": true,
+          "requires": {
+            "comment-parser": "1.3.1",
+            "esquery": "^1.5.0",
+            "jsdoc-type-pratt-parser": "~4.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eslint-plugin-jsdoc": {
+          "version": "43.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.2.0.tgz",
+          "integrity": "sha512-Hst7XUfqh28UmPD52oTXmjaRN3d0KrmOZdgtp4h9/VHUJD3Evoo82ZGXi1TtRDWgWhvqDIRI63O49H0eH7NrZQ==",
+          "dev": true,
+          "requires": {
+            "@es-joy/jsdoccomment": "~0.38.0",
+            "are-docs-informative": "^0.0.2",
+            "comment-parser": "1.3.1",
+            "debug": "^4.3.4",
+            "escape-string-regexp": "^4.0.0",
+            "esquery": "^1.5.0",
+            "semver": "^7.5.0",
+            "spdx-expression-parse": "^3.0.1"
+          }
+        },
+        "jsdoc-type-pratt-parser": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+          "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "eslint-config-standard": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
-      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
+      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
       "dev": true,
       "requires": {}
     },
     "eslint-config-standard-with-typescript": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-23.0.0.tgz",
-      "integrity": "sha512-iaaWifImn37Z1OXbNW1es7KI+S7D408F9ys0bpaQf2temeBWlvb0Nc5qHkOgYaRb5QxTZT32GGeN1gtswASOXA==",
+      "version": "34.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-34.0.1.tgz",
+      "integrity": "sha512-J7WvZeLtd0Vr9F+v4dZbqJCLD16cbIy4U+alJMq4MiXdpipdBM3U5NkXaGUjePc4sb1ZE01U9g6VuTBpHHz1fg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "^5.0.0",
+        "@typescript-eslint/parser": "^5.43.0",
         "eslint-config-standard": "17.0.0"
+      },
+      "dependencies": {
+        "eslint-config-standard": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+          "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "eslint-etc": {
@@ -40297,9 +40764,9 @@
       }
     },
     "eslint-plugin-n": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.3.0.tgz",
-      "integrity": "sha512-IyzPnEWHypCWasDpxeJnim60jhlumbmq0pubL6IOcnk8u2y53s5QfT8JnXy7skjHJ44yWHRb11PLtDHuu1kg/Q==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -40307,10 +40774,10 @@
         "eslint-plugin-es": "^4.1.0",
         "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "is-core-module": "^2.10.0",
+        "is-core-module": "^2.11.0",
         "minimatch": "^3.1.2",
         "resolve": "^1.22.1",
-        "semver": "^7.3.7"
+        "semver": "^7.3.8"
       },
       "dependencies": {
         "builtins": {
@@ -40364,9 +40831,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -43088,9 +43555,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -46014,6 +46481,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "ndjson": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "browserslist": "^4.21.4",
     "check-aegir-project": "^1.1.1",
     "cp-cli": "^2.0.0",
-    "eslint-config-ipfs": "^3.1.2",
+    "eslint-config-ipfs": "^4.0.3",
     "eslint-plugin-compat": "^4.0.2",
     "fetch-ponyfill": "^7.1.0",
     "ipfs": "^0.65.0",

--- a/src/CheckBase.ts
+++ b/src/CheckBase.ts
@@ -1,7 +1,8 @@
+import { UiComponent } from './UiComponent'
 import type { Checker } from './Checker'
 import type { GatewayNode } from './GatewayNode'
 import type { Tag } from './Tag'
-import { UiComponent } from './UiComponent'
+import type { Checkable } from './types'
 
 /**
  * Base Check functionality

--- a/src/Checker.ts
+++ b/src/Checker.ts
@@ -1,8 +1,8 @@
 
 import { GatewayNode } from './GatewayNode'
+import { Log } from './Log'
 import { Results } from './Results'
 import { Stats } from './Stats'
-import { Log } from './Log'
 
 const log = new Log('Checker')
 
@@ -34,7 +34,7 @@ class Checker {
       this.results.append(node.tag)
       // void node.check()
       setTimeout(() => {
-        allChecks.push(node.check().catch((err) => log.error(err)).finally(this.updateStats))
+        allChecks.push(node.check().catch((err) => { log.error(err) }).finally(this.updateStats))
       }, 100 * this.nodes.length)
     }
     // await Promise.all(allChecks).finally(this.updateStats)

--- a/src/Cors.ts
+++ b/src/Cors.ts
@@ -1,10 +1,9 @@
 import fetchPonyfill from 'fetch-ponyfill'
-
 import { CheckBase } from './CheckBase'
+import { Log } from './Log'
 import { HASH_STRING, HASH_TO_TEST } from './constants'
 import type { GatewayNode } from './GatewayNode'
-
-import { Log } from './Log'
+import type { Checkable } from './types'
 
 const { fetch } = fetchPonyfill()
 

--- a/src/Flag.ts
+++ b/src/Flag.ts
@@ -98,7 +98,8 @@ class Flag extends UiComponent {
   async handleDnsQueryResponse (response: DnsQueryResponse): Promise<void> {
     if (response.Answer == null) {
       log.error('Response does not contain the "Answer" property:', response)
-      this.onError(); return
+      this.onError()
+      return
     }
     let ip = null
     for (let i = 0; i < response.Answer.length && ip == null; i++) {

--- a/src/Flag.ts
+++ b/src/Flag.ts
@@ -1,9 +1,10 @@
-import type { GatewayNode } from './GatewayNode'
-import { Log } from './Log'
-import { lookup as IpfsGeoIpLookup } from 'ipfs-geoip'
-import { UiComponent } from './UiComponent'
 import { TokenBucketLimiter } from '@dutu/rate-limiter'
+import { lookup as IpfsGeoIpLookup } from 'ipfs-geoip'
+import { Log } from './Log'
+import { UiComponent } from './UiComponent'
 import { DEFAULT_IPFS_GATEWAY } from './constants'
+import type { GatewayNode } from './GatewayNode'
+import type { DnsQueryResponse } from './types'
 
 const log = new Log('Flag')
 
@@ -71,7 +72,7 @@ class Flag extends UiComponent {
     if (url == null) {
       // No available tokens...
       log.info('we awaited tokens, but could not retrieve any.. restarting dnsRequest')
-      return await this.waitForAvailableEndpoint()
+      return this.waitForAvailableEndpoint()
     } else {
       return url
     }
@@ -97,7 +98,7 @@ class Flag extends UiComponent {
   async handleDnsQueryResponse (response: DnsQueryResponse): Promise<void> {
     if (response.Answer == null) {
       log.error('Response does not contain the "Answer" property:', response)
-      return this.onError()
+      this.onError(); return
     }
     let ip = null
     for (let i = 0; i < response.Answer.length && ip == null; i++) {

--- a/src/GatewayNode.ts
+++ b/src/GatewayNode.ts
@@ -1,17 +1,15 @@
 import { URL } from 'url-ponyfill'
-
 import { Cors } from './Cors'
 import { Flag } from './Flag'
-import { Origin } from './Origin'
-import { Trustless } from './Trustless'
-import type { Results } from './Results'
-import { Status } from './Status'
-import { UiComponent } from './UiComponent'
-
-import { Log } from './Log'
-import { gatewayHostname } from './gatewayHostname'
-import { HASH_TO_TEST } from './constants'
 import { IPNSCheck } from './Ipns'
+import { Log } from './Log'
+import { Origin } from './Origin'
+import { Status } from './Status'
+import { Trustless } from './Trustless'
+import { UiComponent } from './UiComponent'
+import { HASH_TO_TEST } from './constants'
+import { gatewayHostname } from './gatewayHostname'
+import type { Results } from './Results'
 
 const log = new Log('GatewayNode')
 
@@ -77,15 +75,15 @@ class GatewayNode extends UiComponent /* implements Checkable */ {
     this.checkingTime = Date.now()
     // const onFailedCheck = () => { this.status.down = true }
     // const onSuccessfulCheck = () => { this.status.up = true }
-    void this.flag.check().then(() => log.debug(this.gateway, 'Flag success'))
+    void this.flag.check().then(() => { log.debug(this.gateway, 'Flag success') })
     const onlineChecks = [
       // this.flag.check().then(() => log.debug(this.gateway, 'Flag success')),
-      this.status.check().then(() => log.debug(this.gateway, 'Status success')).then(this.onSuccessfulCheck.bind(this)),
-      this.cors.check().then(() => log.debug(this.gateway, 'CORS success')).then(this.onSuccessfulCheck.bind(this)),
-      this.ipns.check().then(() => log.debug(this.gateway, 'IPNS success')).then(this.onSuccessfulCheck.bind(this)),
-      this.origin.check().then(() => log.debug(this.gateway, 'Origin success')).then(this.onSuccessfulCheck.bind(this)),
+      this.status.check().then(() => { log.debug(this.gateway, 'Status success') }).then(this.onSuccessfulCheck.bind(this)),
+      this.cors.check().then(() => { log.debug(this.gateway, 'CORS success') }).then(this.onSuccessfulCheck.bind(this)),
+      this.ipns.check().then(() => { log.debug(this.gateway, 'IPNS success') }).then(this.onSuccessfulCheck.bind(this)),
+      this.origin.check().then(() => { log.debug(this.gateway, 'Origin success') }).then(this.onSuccessfulCheck.bind(this)),
       this.trustless.check().then(
-        () => log.debug(this.gateway, 'Trustless success')).then(this.onSuccessfulCheck.bind(this))
+        () => { log.debug(this.gateway, 'Trustless success') }).then(this.onSuccessfulCheck.bind(this))
     ]
 
     // we care only about the fastest method to return a success

--- a/src/Ipns.ts
+++ b/src/Ipns.ts
@@ -1,10 +1,9 @@
 import fetchPonyfill from 'fetch-ponyfill'
-
 import { CheckBase } from './CheckBase'
+import { Log } from './Log'
 import { IPNS_PATH_TO_TEST } from './constants'
 import type { GatewayNode } from './GatewayNode'
-
-import { Log } from './Log'
+import type { Checkable } from './types'
 
 const { fetch } = fetchPonyfill()
 

--- a/src/Origin.ts
+++ b/src/Origin.ts
@@ -1,12 +1,10 @@
 import { URL } from 'url-ponyfill'
-
-import type { GatewayNode } from './GatewayNode'
-import { Tag } from './Tag'
-
 import { Log } from './Log'
-import { expectSubdomainRedirect } from './expectSubdomainRedirect'
+import { Tag } from './Tag'
 import { checkViaImgSrc } from './checkViaImgSrc'
 import { IMG_HASH } from './constants'
+import { expectSubdomainRedirect } from './expectSubdomainRedirect'
+import type { GatewayNode } from './GatewayNode'
 
 const log = new Log('Origin')
 
@@ -25,13 +23,13 @@ class Origin {
     const imgSubdomainUrl = new URL(`${gwUrl.protocol}//${IMG_HASH}.ipfs.${gwUrl.hostname}/?now=${Date.now()}&filename=1x1.png#x-ipfs-companion-no-redirect`)
     const imgRedirectedPathUrl = new URL(`${gwUrl.protocol}//${gwUrl.hostname}/ipfs/${IMG_HASH}?now=${Date.now()}&filename=1x1.png#x-ipfs-companion-no-redirect`)
     await checkViaImgSrc(imgSubdomainUrl)
-      .then(async () => await expectSubdomainRedirect(imgRedirectedPathUrl))
+      .then(async () => expectSubdomainRedirect(imgRedirectedPathUrl))
       .then(() => {
         this.tag.win(imgSubdomainUrl.toString())
         this.parent.tag.classList.add('origin')
         // this.parent.checked()
       })
-      .catch((err) => this.onerror(err))
+      .catch((err) => { this.onerror(err) })
   }
 
   onerror (err: Error): void {

--- a/src/Stats.ts
+++ b/src/Stats.ts
@@ -1,6 +1,6 @@
-import type { Checker } from './Checker'
 import { Tag } from './Tag'
 import { UiComponent } from './UiComponent'
+import type { Checker } from './Checker'
 
 class Stats extends UiComponent {
   gateways: HTMLDivElement

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -1,11 +1,9 @@
 import { URL } from 'url-ponyfill'
-
-import type { GatewayNode } from './GatewayNode'
-import { UiComponent } from './UiComponent'
-
 import { Log } from './Log'
+import { UiComponent } from './UiComponent'
 import { checkViaImgSrc } from './checkViaImgSrc'
 import { IMG_HASH } from './constants'
+import type { GatewayNode } from './GatewayNode'
 
 const log = new Log('Status')
 

--- a/src/Tag.ts
+++ b/src/Tag.ts
@@ -68,7 +68,7 @@ class Tag {
     if (child instanceof Tag) {
       child = child.element
     }
-    return this.element.append(child)
+    this.element.append(child)
   }
 
   get classList (): DOMTokenList {

--- a/src/Trustless.ts
+++ b/src/Trustless.ts
@@ -1,10 +1,9 @@
 import fetchPonyfill from 'fetch-ponyfill'
-
 import { CheckBase } from './CheckBase'
+import { Log } from './Log'
 import { HASH_TO_TEST, TRUSTLESS_RESPONSE_TYPES } from './constants'
 import type { GatewayNode } from './GatewayNode'
-
-import { Log } from './Log'
+import type { Checkable } from './types'
 
 const { fetch } = fetchPonyfill()
 

--- a/src/UiComponent.ts
+++ b/src/UiComponent.ts
@@ -1,7 +1,8 @@
+import { Tag } from './Tag'
 import type { Checker } from './Checker'
 import type { GatewayNode } from './GatewayNode'
 import type { Results } from './Results'
-import { Tag } from './Tag'
+import type { Visible } from './types'
 
 class UiComponent {
   tag: Tag

--- a/src/checkViaImgSrc.ts
+++ b/src/checkViaImgSrc.ts
@@ -7,7 +7,7 @@ async function checkViaImgSrc (imgUrl: string | URL): Promise<void> {
   // this is more robust check than loading js, as it won't be blocked
   // by privacy protections present in modern browsers or in extensions such as Privacy Badger
   const imgCheckTimeout = 15000
-  return await new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     const img = new Image()
     const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
       // clearTimeout(timer)

--- a/src/expectSubdomainRedirect.ts
+++ b/src/expectSubdomainRedirect.ts
@@ -1,7 +1,6 @@
 import { URL } from 'url-ponyfill'
-import { IMG_HASH } from './constants'
-
 import { Log } from './Log'
+import { IMG_HASH } from './constants'
 
 const log = new Log('expectSubdomainRedirect')
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,36 +1,5 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
-/* eslint-disable etc/prefer-interface */
-
 declare module '@dutu/rate-limiter'
 declare module 'ipfs-geoip'
-
-// declare global {
-/**
- * An interface that allows various properties for gateways to be checked
- */
-interface Checkable {
-
-  // @todo: Update to async/await
-  // check: () => Promise<void>
-  check: () => void
-  checked: () => void
-
-  onerror: () => void
-}
-
-/**
- * A class implementing the Visible interface supports functionality that can make it visible in the UI
- */
-interface Visible {
-  tag: import('./Tag').Tag
-  _tagName: string
-  _className: string
-}
-
-interface Window {
-  OnScriptloaded: typeof import('./onScriptLoaded').onScriptLoaded
-  checker: import('./Checker').Checker
-}
 
 declare namespace IpfsGeoip {
   interface LookupResponse {
@@ -38,25 +7,3 @@ declare namespace IpfsGeoip {
     country_name: string
   }
 }
-interface DnsQueryResponseAnswer { name: string, type: number, TTL: number, data: string }
-interface DnsQueryResponseQuestion { name: string, type: number }
-
-interface DnsQueryResponseAuthority {
-  TTL: number
-  data: string // "aragorn.ns.cloudflare.com. dns.cloudflare.com. 2271826322 10000 2400 604800 3600"
-  name: string // "stibarc.com"
-  type: number
-}
-
-interface DnsQueryResponse {
-  AD: boolean
-  Answer?: DnsQueryResponseAnswer[]
-  Authority?: DnsQueryResponseAuthority[]
-  CD: boolean
-  Question: DnsQueryResponseQuestion[]
-  RA: boolean
-  RD: boolean
-  Status: number
-  TC: boolean
-}
-// }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
+import { Workbox } from 'workbox-window'
 import { Checker } from './Checker'
+import { Log } from './Log'
 import gateways from './gateways.json'
 import { loadCountly } from './metrics'
-import { Log } from './Log'
-import { Workbox } from 'workbox-window'
 
 const wb = new Workbox('/sw.js')
 void wb.register()

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,51 @@
+import type { Checker } from './Checker'
+import type { Tag } from './Tag'
+
+declare global {
+  interface Window {
+    checker: Checker
+  }
+}
+/**
+ * An interface that allows various properties for gateways to be checked
+ */
+export interface Checkable {
+
+  // @todo: Update to async/await
+  // check: () => Promise<void>
+  check: () => void
+  checked: () => void
+
+  onerror: () => void
+}
+
+/**
+ * A class implementing the Visible interface supports functionality that can make it visible in the UI
+ */
+export interface Visible {
+  tag: Tag
+  _tagName: string
+  _className: string
+}
+
+export interface DnsQueryResponseAnswer { name: string, type: number, TTL: number, data: string }
+export interface DnsQueryResponseQuestion { name: string, type: number }
+
+export interface DnsQueryResponseAuthority {
+  TTL: number
+  data: string // "aragorn.ns.cloudflare.com. dns.cloudflare.com. 2271826322 10000 2400 604800 3600"
+  name: string // "stibarc.com"
+  type: number
+}
+
+export interface DnsQueryResponse {
+  AD: boolean
+  Answer?: DnsQueryResponseAnswer[]
+  Authority?: DnsQueryResponseAuthority[]
+  CD: boolean
+  Question: DnsQueryResponseQuestion[]
+  RA: boolean
+  RD: boolean
+  Status: number
+  TC: boolean
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,6 @@ export interface Checkable {
   // check: () => Promise<void>
   check: () => void
   checked: () => void
-
   onerror: () => void
 }
 


### PR DESCRIPTION
* Update eslint-config-ipfs.
* Moved app-specific types to types.ts from global.d.ts due to import() type eslint rule violations.
* add type imports where types are needed and used to be globally available.