### PR TITLE
feat: twdragon.net

### DIFF
--- a/src/gateways.ts
+++ b/src/gateways.ts
@@ -80,4 +80,5 @@ export default [
   'https://ipfs.tayfundogdas.me/ipfs/:hash',
   'https://ipfs.jpu.jp/ipfs/:hash',
   'https://ipfs.soul-network.com/ipfs/:hash',
+  'https://ipfs.twdragon.net/ipfs/:hash'
 ]

--- a/src/gateways.ts
+++ b/src/gateways.ts
@@ -80,5 +80,5 @@ export default [
   'https://ipfs.tayfundogdas.me/ipfs/:hash',
   'https://ipfs.jpu.jp/ipfs/:hash',
   'https://ipfs.soul-network.com/ipfs/:hash',
-  'https://ipfs.twdragon.net/ipfs/:hash',
+  'https://twdragon.net/ipfs/:hash',
 ]

--- a/src/gateways.ts
+++ b/src/gateways.ts
@@ -80,5 +80,5 @@ export default [
   'https://ipfs.tayfundogdas.me/ipfs/:hash',
   'https://ipfs.jpu.jp/ipfs/:hash',
   'https://ipfs.soul-network.com/ipfs/:hash',
-  'https://ipfs.twdragon.net/ipfs/:hash'
+  'https://ipfs.twdragon.net/ipfs/:hash',
 ]


### PR DESCRIPTION
Added twdragon.net to the list of public gateways.

**NOTE**: The gateway supports only subdomain addressing, the case-sensitive path-based CID addressing is blocked programmatically.

