### PR TITLE
Delisting twdragon.net

### DIFF
--- a/gateways.txt
+++ b/gateways.txt
@@ -79,4 +79,3 @@ https://cthd.icu
 https://ipfs.tayfundogdas.me
 https://ipfs.jpu.jp
 https://ipfs.soul-network.com
-https://twdragon.net


### PR DESCRIPTION
Due to an abuse request from the American Association of Book Publishers, I should delist my experimental gateway and make it private.