### PR TITLE
fix: Drop my long since disabled gateway from your list

### DIFF
--- a/src/gateways.ts
+++ b/src/gateways.ts
@@ -2,7 +2,6 @@ export default [
   'https://ipfs.io/ipfs/:hash',
   'https://dweb.link/ipfs/:hash',
   'https://gateway.ipfs.io/ipfs/:hash',
-  'https://ninetailed.ninja/ipfs/:hash',
   'https://via0.com/ipfs/:hash',
   'https://ipfs.eternum.io/ipfs/:hash',
   'https://hardbin.com/ipfs/:hash',


### PR DESCRIPTION
I disabled it years ago due to overuse for the small server powering it and all requests on /ipfs/ and /ipns/ will give 404 HTTP errors so having it advertised here or anywhere else is not useful – logs show that people still try to use it even though it doesn’t work.