### PR TITLE
ci: run test and release once conformance ended

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -1,9 +1,11 @@
 name: test & maybe release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["Gateway Conformance Dashboard"]
+    branches: ["master"]
+    types:
+      - completed
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Background

- We have two workflows that run concurrently: "test & maybe release" and "Gateway Conformance Dashboard"
- Both workflows commit to the `master` branch
  - "test & maybe release": creates a release commit with the changelog
  - "Gateway Conformance Dashboard": creates a commit in the [aggregate job](https://github.com/ipfs/public-gateway-checker/blob/master/.github/workflows/gateway-conformance.yml#L87) which updates the conformance results [example](https://github.com/ipfs/public-gateway-checker/commit/44d369f938f9153b15e8c2f024257f756247162e).
- A race condition between the two running causes the `aggregate` job to fail [example](https://github.com/ipfs/public-gateway-checker/actions/runs/7292094626/job/19872849515) [example](https://github.com/ipfs/public-gateway-checker/actions/runs/7814993311/job/21318822444) because other job already committed to the repo.

## Problem
- The list of gateways [used by the frontend](https://github.com/ipfs/public-gateway-checker/blob/master/src/index.ts#L5) is not updated.

## What this PR does

Ensures that the release commit only happens after the "Gateway Conformance Dashboard" workflow has completed (and committed the aggregated report list)

