### PR TITLE
remove duplicate gateways and re-add working one

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -4,6 +4,7 @@
   "https://cloudflare-ipfs.com",
   "https://cf-ipfs.com",
   "https://gateway.pinata.cloud",
+  "https://hardbin.com",
   "https://ipfs.runfission.com",
   "https://ipfs.eth.aragon.network",
   "https://nftstorage.link",

--- a/gateways.json
+++ b/gateways.json
@@ -1,13 +1,11 @@
 [
   "https://ipfs.io",
   "https://dweb.link",
-  "https://gateway.ipfs.io",
   "https://cloudflare-ipfs.com",
   "https://cf-ipfs.com",
   "https://gateway.pinata.cloud",
   "https://ipfs.runfission.com",
   "https://ipfs.eth.aragon.network",
-  "https://permaweb.eu.org",
   "https://nftstorage.link",
   "https://4everland.io",
   "https://w3s.link",


### PR DESCRIPTION
## background

This should be the last clean up PR:

- `gateway.ipfs.io` is the same as `ipfs.io` (the DNS records resolve to the same IP). There's no benefit in having both
- `permaweb.eu.org` redirects to `ipfs.io` 
- re-add `hardbin.com` (see https://github.com/ipfs/public-gateway-checker/pull/532#issuecomment-1961931034)

## Test results

```
http https://permaweb.eu.org/ipfs/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4
HTTP/1.1 302 Moved Temporarily
CF-RAY: 85bfefa45e884294-EWR
Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Connection: keep-alive
Date: Tue, 27 Feb 2024 11:02:32 GMT
Expires: Thu, 01 Jan 1970 00:00:01 GMT
Location: https://ipfs.io/ipfs/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4
NEL: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
Report-To: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=quBDMvZjtYCqFpE0WFe5smgvNCrP6HnbT1kDC5bhEsLm%2BAph8NNiYKcPwgg1c07Ru0ZUHP8cDYyWjnBcjhJBO3GnvX8QYxp8D4NdVYOfb9NYYG1bWXZfl3XK8XafaO4n%2FkA%3D"}],"group":"cf-nel","max_age":604800}
Server: cloudflare
Strict-Transport-Security: max-age=15552000; includeSubDomains; preload
Transfer-Encoding: chunked
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
alt-svc: h3=":443"; ma=86400
```


```
http "https://hardbin.com/ipfs/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4?format=raw"
HTTP/1.1 200 OK
Accept-Ranges: bytes
Access-Control-Allow-Headers: Content-Type, Range, User-Agent, X-Requested-With
Access-Control-Allow-Methods: GET
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Content-Length, Content-Range, X-Chunked-Output, X-Ipfs-Path, X-Ipfs-Roots, X-Stream-Output
Cache-Control: public, max-age=29030400, immutable
Connection: keep-alive
Content-Disposition: attachment; filename="bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4.bin"; filename*=UTF-8''bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4.bin
Content-Length: 108
Content-Type: application/vnd.ipld.raw
Date: Tue, 27 Feb 2024 11:17:17 GMT
Debug-Hash: bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4
Etag: "bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4.raw"
Server: nginx/1.18.0 (Ubuntu)
X-Content-Type-Options: nosniff
X-Ipfs-Path: /ipfs/bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4
X-Ipfs-Roots: bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4



+-----------------------------------------+
| NOTE: binary data not shown in terminal |
+-----------------------------------------+
```