### PR TITLE
feat: add storry.tv

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -1,4 +1,5 @@
 [
+  "https://storry.tv",
   "https://ipfs.io",
   "https://dweb.link",
   "https://cloudflare-ipfs.com",


### PR DESCRIPTION
The gateway was removed from the list, because of some issues/bots making the gateway not respond.

Most issues should be fixed for now as the gateway is online and working fine again.

In the readme.md it says "Add the gateway's address to the top of the list", so therefore I added it to the top.
