### PR TITLE
chore: Delist CloudFlare's gateways due to their discontinuation.

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -2,8 +2,6 @@
   "https://storry.tv",
   "https://ipfs.io",
   "https://dweb.link",
-  "https://cloudflare-ipfs.com",
-  "https://cf-ipfs.com",
   "https://gateway.pinata.cloud",
   "https://hardbin.com",
   "https://ipfs.runfission.com",


### PR DESCRIPTION
CloudFlare has deprecated the public IPFS gateways.
