### PR TITLE
fix: remove dwt.my.id

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -1,5 +1,4 @@
 [
-  "https://dwt.my.id",
   "https://flk-ipfs.io",
   "https://ipfs.cyou",
   "https://dlunar.net",

--- a/gateways.json
+++ b/gateways.json
@@ -1,4 +1,5 @@
 [
+  "https://dwt.my.id",
   "https://flk-ipfs.io",
   "https://ipfs.cyou",
   "https://dlunar.net",


### PR DESCRIPTION
Deceptive site detected, forced to delist temporarily while fixing this problem. Maybe later it will be published again with a new domain. Sorry if it's a hassle in this very short period of time (not even a month)