### PR TITLE
add ipfs.ecolatam.com

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -12,5 +12,6 @@
   "https://nftstorage.link",
   "https://4everland.io",
   "https://w3s.link",
-  "https://trustless-gateway.link"
+  "https://trustless-gateway.link",
+  "https://ipfs.ecolatam.com"
 ]


### PR DESCRIPTION
Adding EcoLATAM's IPFS Gateway

- Gateway: https://ipfs.ecolatam.com
- Space: 100 GB
- RAM: 3 GB
- Connection Speed: 2 Gbps upload / 1.5 Gbps download
- Location: Hostinger (Europe, exact DC unknown)

This gateway is publicly accessible and intended to support IPFS users in Latin America and globally.
