### PR TITLE
feat: re-add ipfs.cyou

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -7,6 +7,7 @@
   "https://dget.top",
   "https://storry.tv",
   "https://ipfs.io",
+  "https://ipfs.cyou",
   "https://dweb.link",
   "https://gateway.pinata.cloud",
   "https://4everland.io",


### PR DESCRIPTION
The domain was on serverHold (apparently due to an abuse report which I seem to not have received for some reason).

It now got un-held.